### PR TITLE
イベント表示のコンポーネントを作成

### DIFF
--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -1,28 +1,20 @@
 import React from 'react';
 import Link from 'next/link';
 import styles from './Page.module.css';
+import EventCard from '../../components/EventCard'; // Adjust the import path if necessary
 
-const events = [
-  { id: '1', name: 'event1' },
-  { id: '2', name: 'event2' },
-  { id: '3', name: 'event3' },
-  { id: '4', name: 'event4' },
-  { id: '5', name: 'event5' }
+const mock_events = [
+  { id: '1', name: 'Watnowハッカソン2024', date: '2024-9', comment: 'みんな開発をいっぱい頑張りました！' },
+  { id: '2', name: 'Watnowハッカソン2024 春プロ', date: '2024-4', comment: 'みんな開発をいっぱい頑張りました！' },
+  { id: '3', name: 'Watnowハッカソン2024 秋プロ', date: '2024-9', comment: 'みんな開発をいっぱい頑張りました！' }
 ];
 
 const Home: React.FC = () => {
   return (
     <div className={styles.pageHeader}>
       <h1>これはイベント一覧ページです</h1>
-      <ul className={styles.eventList}>
-        {events.map((event) => (
-          <li key={event.id} className={styles.eventItem}>
-            <Link href={`/events/${event.id}`} className={styles.eventLink}>
-              {event.name}
-            </Link>
-          </li>
-        ))}
-      </ul>
+      
+      <EventCard events={mock_events} />
       <Link href="/events/new" className={styles.newEventButton}>
         新規作成
       </Link>

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -9,12 +9,13 @@ const mock_events = [
   { id: '3', name: 'Watnowハッカソン2024 秋プロ', date: '2024-9', comment: 'みんな開発をいっぱい頑張りました！' }
 ];
 
-const Home: React.FC = () => {
+const EventPage: React.FC = () => {
   return (
     <div className={styles.pageHeader}>
       <h1>これはイベント一覧ページです</h1>
-      
-      <EventCard events={mock_events} />
+      {mock_events.map((event) => (
+        <EventCard key={event.id} event={event} />
+       ))}
       <Link href="/events/new" className={styles.newEventButton}>
         新規作成
       </Link>
@@ -22,4 +23,5 @@ const Home: React.FC = () => {
   );
 };
 
-export default Home;
+export default EventPage;
+

--- a/src/components/EventCard.module.css
+++ b/src/components/EventCard.module.css
@@ -1,0 +1,36 @@
+/* 全体のリストをスタイリング */
+.event {
+    list-style-type: none; /* デフォルトのリストスタイルを無効化 */
+    padding: 0; /* 余白を取り除く */
+    margin: 0; /* 外側の余白を取り除く */
+  }
+  
+  /* 各イベントカードのスタイリング */
+  .card {
+    border: 1px solid #ccc; /* カードの枠線 */
+    margin-bottom: 10px; /* カード間の余白 */
+    padding: 15px; /* カード内の余白 */
+    border-radius: 8px; /* カードの角を丸める */
+    transition: box-shadow 0.3s ease; /* ホバー時の影の変化をアニメーション */
+  }
+  
+  /* カードにホバーしたときの影のエフェクト */
+  .card:hover {
+    box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.1); /* ホバー時の影 */
+  }
+  
+  /* 日付をスタイリング */
+  .date {
+    margin: 0; /* 日付の外側の余白を取り除く */
+    font-size: 1.2em; /* 日付のフォントサイズを指定 */
+    color: #333; /* 日付の文字色 */
+    font-weight: bold; /* 日付を太字に */
+  }
+  
+  /* コメントのスタイリング */
+  .comment {
+    margin-top: 8px; /* コメントの上部に余白を追加 */
+    color: #666; /* コメントの文字色 */
+    font-size: 1em; /* コメントのフォントサイズを指定 */
+  }
+  

--- a/src/components/EventCard.module.css
+++ b/src/components/EventCard.module.css
@@ -1,36 +1,36 @@
-/* 全体のリストをスタイリング */
-.event {
-    list-style-type: none; /* デフォルトのリストスタイルを無効化 */
-    padding: 0; /* 余白を取り除く */
-    margin: 0; /* 外側の余白を取り除く */
-  }
-  
-  /* 各イベントカードのスタイリング */
-  .card {
-    border: 1px solid #ccc; /* カードの枠線 */
-    margin-bottom: 10px; /* カード間の余白 */
-    padding: 15px; /* カード内の余白 */
-    border-radius: 8px; /* カードの角を丸める */
-    transition: box-shadow 0.3s ease; /* ホバー時の影の変化をアニメーション */
-  }
-  
-  /* カードにホバーしたときの影のエフェクト */
-  .card:hover {
-    box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.1); /* ホバー時の影 */
-  }
-  
-  /* 日付をスタイリング */
-  .date {
-    margin: 0; /* 日付の外側の余白を取り除く */
-    font-size: 1.2em; /* 日付のフォントサイズを指定 */
-    color: #333; /* 日付の文字色 */
-    font-weight: bold; /* 日付を太字に */
-  }
-  
-  /* コメントのスタイリング */
-  .comment {
-    margin-top: 8px; /* コメントの上部に余白を追加 */
-    color: #666; /* コメントの文字色 */
-    font-size: 1em; /* コメントのフォントサイズを指定 */
-  }
-  
+.cardLink {
+    display: block;
+    padding: 16px;
+    margin: 12px 0;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    text-decoration: none;
+    color: #333;
+    background-color: #f9f9f9;
+    transition: background-color 0.3s ease, transform 0.3s ease;
+}
+
+.cardLink:hover {
+    background-color: #e9e9e9;
+    transform: translateY(-3px);
+}
+
+.eventName {
+    font-size: 1.5rem;
+    font-weight: bold;
+    margin: 0;
+    color: #2c3e50;
+}
+
+.eventDate {
+    font-size: 1rem;
+    font-weight: normal;
+    margin: 4px 0;
+    color: #7f8c8d;
+}
+
+.eventComment {
+    font-size: 1rem;
+    margin-top: 8px;
+    color: #34495e;
+}

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import Link from 'next/link';
+import styles from './EventCard.module.css'; // Corrected the path
+
+// Eventオブジェクトの型を定義
+interface Event {
+    id: string; 
+    name: string;
+    date: string;
+    comment: string;
+}
+
+// Eventコンポーネントが受け取るpropsについて定義
+interface EventCardProps {
+    events: Event[];
+}
+
+const EventCard: React.FC<EventCardProps> = ({ events }) => {
+    return (
+        <ul className={styles.event}>
+            {events.map(event => (
+                <li key={event.id} className={styles.card}>
+                    <Link href={`/events/${event.id}`} className={styles.cardLink}>
+                        <h2 className={styles.name}>{event.name}</h2>
+                        <h2 className={styles.date}>{event.date}</h2>
+                        <p className={styles.comment}>{event.comment}</p>
+                    </Link>
+                </li>
+            ))}
+        </ul>
+    );
+};
+
+export default EventCard;

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -1,33 +1,20 @@
 import React from 'react';
 import Link from 'next/link';
-import styles from './EventCard.module.css'; // Corrected the path
-
-// Eventオブジェクトの型を定義
-interface Event {
-    id: string; 
-    name: string;
-    date: string;
-    comment: string;
-}
+import styles from './EventCard.module.css'; 
+import { Event } from '../types/Event'; // interface Event のimport
 
 // Eventコンポーネントが受け取るpropsについて定義
-interface EventCardProps {
-    events: Event[];
+interface EventCardProp {
+    event: Event;
 }
 
-const EventCard: React.FC<EventCardProps> = ({ events }) => {
+const EventCard: React.FC<EventCardProp> = ({ event }) => {
     return (
-        <ul className={styles.event}>
-            {events.map(event => (
-                <li key={event.id} className={styles.card}>
-                    <Link href={`/events/${event.id}`} className={styles.cardLink}>
-                        <h2 className={styles.name}>{event.name}</h2>
-                        <h2 className={styles.date}>{event.date}</h2>
-                        <p className={styles.comment}>{event.comment}</p>
-                    </Link>
-                </li>
-            ))}
-        </ul>
+        <Link href={`/events/${event.id}`} className={styles.cardLink}>
+            <h2 className={styles.eventName}>{event.name}</h2>
+            <h3 className={styles.eventDate}>{event.date}</h3>
+            <p className={styles.eventComment}>{event.comment}</p>
+        </Link>
     );
 };
 

--- a/src/types/Event.ts
+++ b/src/types/Event.ts
@@ -1,0 +1,7 @@
+//Eventの型定義
+export interface Event {
+    id: string; 
+    name: string;
+    date: string;
+    comment: string;
+}


### PR DESCRIPTION


## 実装内容
   - イベント表示のためのコンポーネント(EventList)の作成
## 関連issue
   - #16 
## 結果画像
   - <img src="https://github.com/user-attachments/assets/90a5513f-8d57-449b-bdff-11597e1eb077" width="250">
   
## 特にみて欲しい部分
   - 特になし
## 今回作れなかった部分
   - 特になし
## 補足
   - issueのところには受け取る要素をname,date,commetの3つに指定されてましたが、ページ遷移等の関係でモックデータにidを追加して4つの要素で実装してあります。