### PR TITLE
eventに関する各ページにてsupabaseと連携させました

### DIFF
--- a/src/app/events/[event_id]/edit/page.tsx
+++ b/src/app/events/[event_id]/edit/page.tsx
@@ -12,8 +12,8 @@ export default function EventEditPage() {
   const params = useParams();
   const event_id: string = params.event_id as string;
   const [event, setEvent] = useState<EventDetail | null>(null);
-  const [title, setTitle] = useState('');
-  const [description, setDescription] = useState('');
+  const [name, setName] = useState('');
+  const [comment, setComment] = useState('');
   const [url, setUrl] = useState('');
   const [loading, setLoading] = useState(true);
 
@@ -31,8 +31,8 @@ export default function EventEditPage() {
           setEvent(null);
         } else {
           setEvent(data as EventDetail);
-          setTitle(data.name);
-          setDescription(data.comment);
+          setName(data.name);
+          setComment(data.comment);
           setUrl(data.url);
         }
         setLoading(false);
@@ -53,13 +53,13 @@ export default function EventEditPage() {
   const handleSaveClick = async () => {
     const { error } = await supabase
       .from('events')
-      .update({ name: title, comment: description, url: url })
+      .update({ name: name, comment: comment, url: url })
       .eq('id', event_id);
 
     if (error) {
       console.error('Error updating event:', error);
     } else {
-      console.log('Event updated successfully:', { title, description, url });
+      console.log('Event updated successfully:', { name, comment, url });
       // 編集完了後にリンクにより画面遷移が発生
     }
   };
@@ -72,15 +72,16 @@ export default function EventEditPage() {
         <input
           className={styles.input}
           type="text"
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
         />
 
         <label className={styles.label}>説明</label>
         <textarea
           className={styles.textarea}
-          value={description}
-          onChange={(e) => setDescription(e.target.value)}
+          value={comment}
+          onChange={(e) => setComment(e.target.value)}
         />
 
         <label className={styles.label}>URL</label>

--- a/src/app/events/[event_id]/edit/page.tsx
+++ b/src/app/events/[event_id]/edit/page.tsx
@@ -78,7 +78,7 @@ export default function EventEditPage() {
   };
 
   return (
-    <div className={styles.fullScreen}>
+    <main className={styles.fullScreen}>
       <div className={styles.container}>
         <h1 className={styles.title}>イベント編集</h1>
         <label className={styles.label}>タイトル</label>
@@ -115,6 +115,6 @@ export default function EventEditPage() {
           編集完了
         </button>
       </div>
-    </div>
+    </main>
   );
 }

--- a/src/app/events/[event_id]/edit/page.tsx
+++ b/src/app/events/[event_id]/edit/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useParams } from 'next/navigation';
-import Link from 'next/link';
+import { useParams, useRouter } from 'next/navigation';
 import styles from './page.module.css';
 import { useEffect, useState } from 'react';
 import LoadingSpinner from '../../../../components/LoadingSpinner';
@@ -10,12 +9,24 @@ import { EventDetail } from '@/types/Event';
 
 export default function EventEditPage() {
   const params = useParams();
+  const router = useRouter();
   const event_id: string = params.event_id as string;
-  const [event, setEvent] = useState<EventDetail | null>(null);
-  const [name, setName] = useState('');
-  const [comment, setComment] = useState('');
-  const [url, setUrl] = useState('');
+  const [event, setEvent] = useState<EventDetail>({
+    id: '',
+    name: '',
+    date: '',
+    url: '',
+    comment: ''
+  });
   const [loading, setLoading] = useState(true);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { id, value } = e.target;
+    setEvent((prevEvent) => ({
+      ...prevEvent,
+      [id]: value
+    }));
+  };
 
   useEffect(() => {
     const fetchEventData = async () => {
@@ -28,12 +39,14 @@ export default function EventEditPage() {
 
         if (error) {
           console.error('Error fetching event data:', error);
-          setEvent(null);
         } else {
-          setEvent(data as EventDetail);
-          setName(data.name);
-          setComment(data.comment);
-          setUrl(data.url);
+          setEvent({
+            id: data.id,
+            name: data.name,
+            date: data.date,
+            url: data.url,
+            comment: data.comment
+          } as EventDetail);
         }
         setLoading(false);
       }
@@ -53,14 +66,14 @@ export default function EventEditPage() {
   const handleSaveClick = async () => {
     const { error } = await supabase
       .from('events')
-      .update({ name: name, comment: comment, url: url })
+      .update({ name: event.name, comment: event.comment, url: event.url })
       .eq('id', event_id);
 
     if (error) {
       console.error('Error updating event:', error);
     } else {
-      console.log('Event updated successfully:', { name, comment, url });
-      // 編集完了後にリンクにより画面遷移が発生
+      console.log('Event updated successfully:', event);
+      router.push(`/events/${event_id}`);
     }
   };
 
@@ -72,29 +85,35 @@ export default function EventEditPage() {
         <input
           className={styles.input}
           type="text"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
+          id="name"  
+          value={event.name}
+          onChange={handleChange}
           required
         />
 
         <label className={styles.label}>説明</label>
         <textarea
           className={styles.textarea}
-          value={comment}
-          onChange={(e) => setComment(e.target.value)}
+          id="comment"  
+          value={event.comment}
+          onChange={handleChange}
         />
 
         <label className={styles.label}>URL</label>
         <input
           className={styles.input}
           type="text"
-          value={url}
-          onChange={(e) => setUrl(e.target.value)}
+          id="url"  
+          value={event.url}
+          onChange={handleChange}
         />
 
-        <Link href={`/events/${event_id}`} className={styles.saveButton} onClick={handleSaveClick}>
+        <button 
+          className={styles.saveButton} 
+          onClick={handleSaveClick}
+        >
           編集完了
-        </Link>
+        </button>
       </div>
     </div>
   );

--- a/src/app/events/[event_id]/edit/page.tsx
+++ b/src/app/events/[event_id]/edit/page.tsx
@@ -12,7 +12,7 @@ export default function EventEditPage() {
   const router = useRouter();
   const event_id: string = params.event_id as string;
   const [event, setEvent] = useState<EventDetail>({
-    id: '',
+    id: null,
     name: '',
     date: '',
     url: '',

--- a/src/app/events/[event_id]/page.module.css
+++ b/src/app/events/[event_id]/page.module.css
@@ -4,14 +4,14 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    min-height: 100vh; /* ビューポート全体の高さに合わせる */
-    background-color: #f0f0f0; /* 背景色を追加 */
+    min-height: 100vh;
+    background-color: #f0f0f0;
 }
 
 .container {
     padding: 20px;
     max-width: 700px;
-    width: 100%; /* コンテナの幅を100%にして中央揃え */
+    width: 100%;
     background-color: #fff;
     border-radius: 12px;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
@@ -39,6 +39,15 @@
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
+.details {
+    font-size: 1.1rem;
+    color: #555;
+    margin-top: 10px;
+    padding: 8px 20px;
+    background-color: #f5f5f5;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
 .editButton {
     display: inline-block;
     margin-top: 20px;
@@ -51,6 +60,7 @@
     cursor: pointer;
     text-align: center;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    transition: background-color 0.3s;
 }
 
 .editButton:hover {

--- a/src/app/events/[event_id]/page.tsx
+++ b/src/app/events/[event_id]/page.tsx
@@ -5,35 +5,38 @@ import Link from 'next/link';
 import styles from './page.module.css';
 import { useEffect, useState } from 'react';
 import LoadingSpinner from '../../../components/LoadingSpinner';
+import { supabase } from '@/supabase/supabase';
+import { EventDetail } from '@/types/Event';
 
-// mockイベントデータの型を定義
-type EventData = {
-  title: string;
-  description: string;
-};
-
-// mockEventsを定義
-// supabaseでデータ構造が決まり次第変更、APIでデータ取得
-const mockEvents: Record<string, EventData> = {
-  '1': { title: 'イベント 1', description: 'これはイベント 1 の説明です。' },
-  '2': { title: 'イベント 2', description: 'これはイベント 2 の説明です。' },
-  '3': { title: 'イベント 3', description: 'これはイベント 3 の説明です。' },
-  '4': { title: 'イベント 4', description: 'これはイベント 4 の説明です。' },
-};
 
 export default function EventDetailPage() {
   const params = useParams();
   const event_id: string = params.event_id as string;
-  const [event, setEvent] = useState<EventData | null>(null);
+  const [event, setEvent] = useState<EventDetail | null>(null);
   const [loading, setLoading] = useState(true);
 
   // event_idの変更をトリガーにしてsetEventを実行
   useEffect(() => {
-    if (event_id) {
-    const eventData = mockEvents[event_id];
-    setEvent(eventData);
-    setLoading(false);
-    }
+    const fetchEventData = async () => {
+      if (event_id) {
+        const { data, error } = await supabase
+          .from('events')
+          .select('*')
+          .eq('id', event_id)
+          .single();
+        
+        //データ取得時のエラーハンドリング
+        if (error) {
+          console.error('Error fetching event data:', error);
+          setEvent(null);
+        } else {
+          setEvent(data as EventDetail);
+        }
+        setLoading(false);
+      }
+    };
+
+    fetchEventData();
   }, [event_id]);
 
   
@@ -50,8 +53,10 @@ export default function EventDetailPage() {
   return (
     <div className={styles.fullScreen}>
       <div className={styles.container}>
-        <h1 className={styles.title}>{event.title}</h1>
-        <p className={styles.description}>{event.description}</p>
+        <h1 className={styles.title}>{event.name}</h1>
+        <p className={styles.description}>{event.comment}</p>
+        <p className={styles.details}>開催日: {event.date}</p>
+        <p className={styles.details}>URL: {event.url}</p>
         <Link href={`/events/${event_id}/edit`} className={styles.editButton}>
           編集
         </Link>

--- a/src/app/events/[event_id]/page.tsx
+++ b/src/app/events/[event_id]/page.tsx
@@ -51,7 +51,7 @@ export default function EventDetailPage() {
 
   // イベントが正常に処理された場合の処理（イベント詳細を記述）
   return (
-    <div className={styles.fullScreen}>
+    <main className={styles.fullScreen}>
       <div className={styles.container}>
         <h1 className={styles.title}>{event.name}</h1>
         <p className={styles.description}>{event.comment}</p>
@@ -61,6 +61,6 @@ export default function EventDetailPage() {
           編集
         </Link>
       </div>
-    </div>
+    </main>
   );
 }

--- a/src/app/events/new/page.tsx
+++ b/src/app/events/new/page.tsx
@@ -56,7 +56,7 @@ const NewEventPage: React.FC = () => {
   };
 
   return (
-    <div className={styles.container}>
+    <main className={styles.container}>
       <h1 className={styles.title}>新規イベント作成</h1>
       <form onSubmit={handleSubmit} className={styles.form}>
         <div className={styles.formGroup}>
@@ -105,7 +105,7 @@ const NewEventPage: React.FC = () => {
         </button>
         {error && <p className={styles.error}>{error}</p>}
       </form>
-    </div>
+    </main>
   );
 };
 

--- a/src/app/events/new/page.tsx
+++ b/src/app/events/new/page.tsx
@@ -82,14 +82,13 @@ const NewEventPage: React.FC = () => {
           />
         </div>
         <div className={styles.formGroup}>
-          <label htmlFor="url" className={styles.label}>URL</label>
+          <label htmlFor="関連url" className={styles.label}>URL</label>
           <input
-            type="text"
+            type="url"
             id="url"
             value={event.url}
             onChange={handleChange}
             className={styles.input}
-            required
           />
         </div>
         <div className={styles.formGroup}>

--- a/src/app/events/new/page.tsx
+++ b/src/app/events/new/page.tsx
@@ -4,18 +4,31 @@ import React, { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import styles from './page.module.css';
 import { supabase } from '@/supabase/supabase';
+import { EventDetail } from '@/types/Event';
 
 const NewEventPage: React.FC = () => {
   const router = useRouter();
-  // 各イベントの状態管理
-  const [eventName, setEventName] = useState('');
-  const [eventDate, setEventDate] = useState('');
-  const [eventUrl, setEventUrl] = useState('');
-  const [eventComment, setEventComment] = useState('');
+  
+  // EventDetail型に基づく初期状態を設定
+  const [event, setEvent] = useState<EventDetail>({
+    id: '', // idは新規作成時には空文字列
+    name: '',
+    date: '',
+    url: '',
+    comment: ''
+  });
   
   // 登録完了状態管理
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { id, value } = e.target;
+    setEvent((prevEvent) => ({
+      ...prevEvent,
+      [id]: value
+    }));
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -24,7 +37,12 @@ const NewEventPage: React.FC = () => {
 
     const { data, error } = await supabase
       .from('events')
-      .insert([{ name: eventName, date: eventDate, url: eventUrl, comment: eventComment }]);
+      .insert([{ 
+        name: event.name, 
+        date: event.date, 
+        url: event.url, 
+        comment: event.comment 
+      }]);
 
     if (error) {
       console.error('Error inserting event:', error);
@@ -42,44 +60,44 @@ const NewEventPage: React.FC = () => {
       <h1 className={styles.title}>新規イベント作成</h1>
       <form onSubmit={handleSubmit} className={styles.form}>
         <div className={styles.formGroup}>
-          <label htmlFor="eventName" className={styles.label}>イベント名</label>
+          <label htmlFor="name" className={styles.label}>イベント名</label>
           <input
             type="text"
-            id="eventName"
-            value={eventName}
-            onChange={(e) => setEventName(e.target.value)}
+            id="name"
+            value={event.name}
+            onChange={handleChange}
             className={styles.input}
             required
           />
         </div>
         <div className={styles.formGroup}>
-          <label htmlFor="eventDate" className={styles.label}>開催日</label>
+          <label htmlFor="date" className={styles.label}>開催日</label>
           <input
             type="date"
-            id="eventDate"
-            value={eventDate}
-            onChange={(e) => setEventDate(e.target.value)}
+            id="date"
+            value={event.date}
+            onChange={handleChange}
             className={styles.input}
             required
           />
         </div>
         <div className={styles.formGroup}>
-          <label htmlFor="eventUrl" className={styles.label}>URL</label>
+          <label htmlFor="url" className={styles.label}>URL</label>
           <input
             type="text"
-            id="eventUrl"
-            value={eventUrl}
-            onChange={(e) => setEventUrl(e.target.value)}
+            id="url"
+            value={event.url}
+            onChange={handleChange}
             className={styles.input}
             required
           />
         </div>
         <div className={styles.formGroup}>
-          <label htmlFor="eventComment" className={styles.label}>コメント</label>
+          <label htmlFor="comment" className={styles.label}>コメント</label>
           <textarea
-            id="eventComment"
-            value={eventComment}
-            onChange={(e) => setEventComment(e.target.value)}
+            id="comment"
+            value={event.comment}
+            onChange={handleChange}
             className={styles.textarea}
             required
           />

--- a/src/app/events/new/page.tsx
+++ b/src/app/events/new/page.tsx
@@ -98,7 +98,6 @@ const NewEventPage: React.FC = () => {
             value={event.comment}
             onChange={handleChange}
             className={styles.textarea}
-            required
           />
         </div>
         <button type="submit" className={styles.button} disabled={loading}>

--- a/src/app/events/new/page.tsx
+++ b/src/app/events/new/page.tsx
@@ -11,7 +11,7 @@ const NewEventPage: React.FC = () => {
   
   // EventDetail型に基づく初期状態を設定
   const [event, setEvent] = useState<EventDetail>({
-    id: '', // idは新規作成時には空文字列
+    id: null, 
     name: '',
     date: '',
     url: '',

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -5,9 +5,10 @@ import Link from 'next/link';
 import styles from './Page.module.css';
 import EventCard from '../../components/EventCard'; 
 import { supabase } from '../../supabase/supabase';
+import { Event } from '../../types/Event';
 
 const EventPage: React.FC = () => {
-  const [events, setEvents] = useState<any[]>([]);
+  const [events, setEvents] = useState<Event[]>([]);
 
   useEffect(() => {
     const fetchEvents = async () => {
@@ -21,7 +22,7 @@ const EventPage: React.FC = () => {
         console.error('Error fetching events:', error);
       } else {
         console.log('Fetched data:', data); // デバッグ用に取得データを出力
-        setEvents(data || []); // データがnullのときの対策として空配列を設定
+        setEvents(data as Event[] || []); // データがnullのときの対策として空配列を設定
       }
 
     };

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -33,7 +33,7 @@ const EventPage: React.FC = () => {
 
 
   return (
-    <div className={styles.pageHeader}>
+    <main className={styles.pageHeader}>
       <h1>これはイベント一覧ページです</h1>
       {events.map((event) => (       
         <EventCard key={event.id} event={event} />
@@ -41,7 +41,7 @@ const EventPage: React.FC = () => {
       <Link href="/events/new" className={styles.newEventButton}>
         新規作成
       </Link>
-    </div>
+    </main>
   );
 };
 

--- a/src/types/Event.ts
+++ b/src/types/Event.ts
@@ -1,6 +1,6 @@
 //Event一覧ページで利用する型定義
 export interface Event {
-    id: string; 
+    id: string | null; 
     name: string;
     date?: string;
     comment?: string;

--- a/src/types/Event.ts
+++ b/src/types/Event.ts
@@ -2,15 +2,11 @@
 export interface Event {
     id: string; 
     name: string;
-    date: string;
-    comment: string;
+    date?: string;
+    comment?: string;
 }
 
 //Event詳細ページで利用する型定義
-export interface EventDetail{
-    id: string
-    name: string
-    date: string
-    comment: string
-    url: string
+export interface EventDetail extends Event{
+    url?: string
 }

--- a/src/types/Event.ts
+++ b/src/types/Event.ts
@@ -1,7 +1,16 @@
-//Eventの型定義
+//Event一覧ページで利用する型定義
 export interface Event {
     id: string; 
     name: string;
     date: string;
     comment: string;
+}
+
+//Event詳細ページで利用する型定義
+export interface EventDetail{
+    id: string
+    name: string
+    date: string
+    comment: string
+    url: string
 }


### PR DESCRIPTION
## 実装内容
   - イベント詳細ページで表示する情報をsupabaseと連携
   - イベント編集ページの変更をDBに反映できるようにsupabaseと連携
   - イベント新規登録ページでDBに新たなイベントを追加できるようにsupabaseと連携
## 関連issue
   - #4 
## 結果画像
   - これまでの一覧画面
   <img src="https://github.com/user-attachments/assets/0e0ca27b-eea1-4dde-9b73-22e7609bf377" width="250">

   - 新規イベント登録画面
   <img src="https://github.com/user-attachments/assets/071ac09b-0f38-4cb8-9dbb-0a5ef2469279" width="250">

   - 新規イベントの登録後一覧画面
   <img src="https://github.com/user-attachments/assets/11532c86-12fc-4678-a382-fa1080783bac" width="250">

   - イベント詳細画面
   <img src="https://github.com/user-attachments/assets/fdec847c-3827-4b49-8e5c-0a7d7a068ce3" width="250">

   - イベント編集画面
   <img src="https://github.com/user-attachments/assets/b53ef7c8-defa-46ed-8b49-3c7470e64717" width="250">

   - イベントの編集後詳細画面
   <img src="https://github.com/user-attachments/assets/c7d2e167-19b0-4c48-b12e-d91bb088c074" width="250">
 

## 特にみて欲しい部分
   - 特になし
## 今回作れなかった部分
   - 特になし
## 補足
   - supabaseのpolicyについて.updateと.insertについての権限が必要だったので新たにpolicyを追加しました(今のところちゃんと動作するのは確認済みですが、login機能とかを実装したときに権限の部分で変更が必要かもしれません)
