### PR TITLE
ユーザの詳細画面追加

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,8 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+    images: {
+        domains: [process.env.NEXT_PUBLIC_SUPABASE_DOMAIN],
+    },
+};
 
 export default nextConfig;

--- a/src/app/user/[user_id]/page.module.css
+++ b/src/app/user/[user_id]/page.module.css
@@ -1,0 +1,8 @@
+.main{
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+    background-color: #f0f0f0;
+}

--- a/src/app/user/[user_id]/page.tsx
+++ b/src/app/user/[user_id]/page.tsx
@@ -26,18 +26,16 @@ const UserPage = ({ params }: { params: { user_id: string } }) => {
           break;
         }
       }
-      console.log(imageUrl);
       return imageUrl;
     };
 
     const fetchUserData = async () => {
       const { data, error } = await supabase
         .from("users")
-        .select("user_id, name, nickname, introduction")
+        .select()
         .eq("user_id", userID)
         .single();
 
-      console.log("data:", data);
       if (error) {
         console.error("Error fetching user data:", error);
         setUserData(null);

--- a/src/app/user/[user_id]/page.tsx
+++ b/src/app/user/[user_id]/page.tsx
@@ -3,10 +3,11 @@
 import React, { useEffect, useState } from "react";
 import styles from "./page.module.css";
 import { supabase } from "@/supabase/supabase";
+import type User from "@/types/User";
 
 const UserPage = ({ params }: { params: { user_id: string } }) => {
   const userID = params.user_id;
-  const [userData, setUserData] = useState<any | null>(null);
+  const [userData, setUserData] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -23,7 +24,12 @@ const UserPage = ({ params }: { params: { user_id: string } }) => {
         setUserData(null);
       } else {
         console.log("Fetched data:", data);
-        setUserData(data);
+        setUserData({
+          userID: data?.user_id,
+          name: data?.name,
+          nickname: data?.nickname,
+          introduction: data?.introduction || "",
+        } as User);
       }
       setLoading(false);
     };

--- a/src/app/user/[user_id]/page.tsx
+++ b/src/app/user/[user_id]/page.tsx
@@ -1,36 +1,41 @@
 "use client";
 
-import React from "react";
+import React, { useEffect, useState } from "react";
 import styles from "./page.module.css";
-// import { supabase } from "../../../supabase/supabase";
+import { supabase } from "@/supabase/supabase";
 
 const UserPage = ({ params }: { params: { user_id: string } }) => {
   const userID = params.user_id;
-  // const [events, setEvents] = useState<any[]>([]);
+  const [userData, setUserData] = useState<any | null>(null);
 
-  // useEffect(() => {
-  //   const fetchEvents = async () => {
-  //     const { data, error } = await supabase
-  //       .from("events")
-  //       .select("id, name, date, comment")
-  //       .order("id", { ascending: true }); // 'id'で昇順にソート
+  useEffect(() => {
+    const fetchUserData = async () => {
+      const { data, error } = await supabase
+        .from("users")
+        .select("user_id, name, nickname, introduction")
+        .eq("user_id", userID)
+        .single();
 
-  //     //取得に関するエラーハンドリング
-  //     if (error) {
-  //       console.error("Error fetching events:", error);
-  //     } else {
-  //       console.log("Fetched data:", data); // デバッグ用に取得データを出力
-  //       setEvents(data || []); // データがnullのときの対策として空配列を設定
-  //     }
-  //   };
+      console.log("data:", data);
+      if (error) {
+        console.error("Error fetching user data:", error);
+      } else {
+        console.log("Fetched data:", data);
+        setUserData(data);
+      }
+    };
 
-  //   fetchEvents();
-  // }, []);
+    fetchUserData();
+  }, []);
 
   return (
     <main className={styles.main}>
       <h1>これはユーザの詳細ページです</h1>
       <h2>ユーザID: {userID}</h2>
+      <br />
+      <h3>名前: {userData.name}</h3>
+      <h3>ニックネーム: {userData.nickname}</h3>
+      <h3>自己紹介: {userData.introduction}</h3>
     </main>
   );
 };

--- a/src/app/user/[user_id]/page.tsx
+++ b/src/app/user/[user_id]/page.tsx
@@ -23,8 +23,8 @@ const UserPage = ({ params }: { params: { user_id: string } }) => {
         console.error("Error fetching user data:", error);
         setUserData(null);
       } else {
-        console.log("Fetched data:", data);
         setUserData({
+          id: data?.id,
           userID: data?.user_id,
           name: data?.name,
           nickname: data?.nickname,

--- a/src/app/user/[user_id]/page.tsx
+++ b/src/app/user/[user_id]/page.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import React from "react";
+import styles from "./page.module.css";
+// import { supabase } from "../../../supabase/supabase";
+
+const UserPage = ({ params }: { params: { user_id: string } }) => {
+  const userID = params.user_id;
+  // const [events, setEvents] = useState<any[]>([]);
+
+  // useEffect(() => {
+  //   const fetchEvents = async () => {
+  //     const { data, error } = await supabase
+  //       .from("events")
+  //       .select("id, name, date, comment")
+  //       .order("id", { ascending: true }); // 'id'で昇順にソート
+
+  //     //取得に関するエラーハンドリング
+  //     if (error) {
+  //       console.error("Error fetching events:", error);
+  //     } else {
+  //       console.log("Fetched data:", data); // デバッグ用に取得データを出力
+  //       setEvents(data || []); // データがnullのときの対策として空配列を設定
+  //     }
+  //   };
+
+  //   fetchEvents();
+  // }, []);
+
+  return (
+    <main className={styles.main}>
+      <h1>これはユーザの詳細ページです</h1>
+      <h2>ユーザID: {userID}</h2>
+    </main>
+  );
+};
+
+export default UserPage;

--- a/src/app/user/[user_id]/page.tsx
+++ b/src/app/user/[user_id]/page.tsx
@@ -7,6 +7,7 @@ import { supabase } from "@/supabase/supabase";
 const UserPage = ({ params }: { params: { user_id: string } }) => {
   const userID = params.user_id;
   const [userData, setUserData] = useState<any | null>(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const fetchUserData = async () => {
@@ -23,10 +24,19 @@ const UserPage = ({ params }: { params: { user_id: string } }) => {
         console.log("Fetched data:", data);
         setUserData(data);
       }
+      setLoading(false);
     };
 
     fetchUserData();
   }, []);
+
+  if (loading) {
+    return (
+      <main className={styles.main}>
+        <p>Loading...</p>
+      </main>
+    );
+  }
 
   return (
     <main className={styles.main}>

--- a/src/app/user/[user_id]/page.tsx
+++ b/src/app/user/[user_id]/page.tsx
@@ -20,6 +20,7 @@ const UserPage = ({ params }: { params: { user_id: string } }) => {
       console.log("data:", data);
       if (error) {
         console.error("Error fetching user data:", error);
+        setUserData(null);
       } else {
         console.log("Fetched data:", data);
         setUserData(data);
@@ -34,6 +35,17 @@ const UserPage = ({ params }: { params: { user_id: string } }) => {
     return (
       <main className={styles.main}>
         <p>Loading...</p>
+      </main>
+    );
+  }
+
+  if (!userData) {
+    return (
+      <main className={styles.main}>
+        <h1>これはユーザの詳細ページです</h1>
+        <h2>ユーザID: {userID}</h2>
+        <br />
+        <p>存在しないユーザです</p>
       </main>
     );
   }

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -1,0 +1,7 @@
+//Eventの型定義
+export default interface User {
+    userID: string;
+    name: string;
+    nickname: string;
+    introduction?: string;
+}

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -1,5 +1,6 @@
 //Eventの型定義
 export default interface User {
+    id: string;
     userID: string;
     name: string;
     nickname: string;


### PR DESCRIPTION
## 実装内容
   - ユーザの詳細画面を作成した
   - データはsupabaseから取得済み
   - デザインは仮のまま
   
## 関連issue
   - #24 
   
## 結果画像
| Loading | 詳細画面 | ユーザが存在しなかった場合 |
| ---- | ---- | ---- |
| <img width="1226" alt="スクリーンショット 2024-08-22 16 34 16" src="https://github.com/user-attachments/assets/68a4f9fa-03ff-4f00-86d7-82acf1bc715d"> | <img width="1226" alt="スクリーンショット 2024-08-23 3 15 36" src="https://github.com/user-attachments/assets/1764cd87-9a59-4ce9-bccb-7e9c7d9ceebf"> | <img width="1226" alt="スクリーンショット 2024-08-23 3 15 50" src="https://github.com/user-attachments/assets/f38d0d25-baaa-4da6-b418-40a3ac647390"> |

# 確認方法
- Loading: http://localhost:3000/user/◯◯ (なんでも、ローディング中表示)
- ユーザー: http://localhost:3000/user/hoge
- 存在しないユーザ: http://localhost:3000/user/yuka

user_idはsupabaseのこの部分が一致すればでる
<img width="1226" alt="スクリーンショット 2024-08-23 14 02 23" src="https://github.com/user-attachments/assets/0f822449-af8e-4e3e-9243-b40344b9d891">


## 特にみて欲しい部分
   - supabaseのpolicy設定
## 今回作れなかった部分
   - 作ったサービス一覧の取得と表示
   - supabseの適切なpolicy設定
## 補足
   - 