### PR TITLE
イベントページに賞の登録機能を追加

### DIFF
--- a/src/app/events/[event_id]/edit/page.tsx
+++ b/src/app/events/[event_id]/edit/page.tsx
@@ -5,7 +5,8 @@ import styles from "./page.module.css";
 import { useEffect, useState } from "react";
 import LoadingSpinner from "../../../../components/LoadingSpinner";
 import { supabase } from "@/supabase/supabase";
-import { EventDetail, Award } from "@/types/Event";
+import { EventDetail } from "@/types/Event";
+import { Award } from "@/types/Award"
 
 export default function EventEditPage() {
   const params = useParams();

--- a/src/app/events/[event_id]/edit/page.tsx
+++ b/src/app/events/[event_id]/edit/page.tsx
@@ -71,7 +71,6 @@ export default function EventEditPage() {
           .select('*')
           .eq('id', event_id)
           .single();
-  
         if (eventError) {
           console.error('Error fetching event data:', eventError);
         } else {
@@ -84,6 +83,7 @@ export default function EventEditPage() {
             comment: eventData.comment
           }));
         }        
+        //賞のリストを取得
         const { data: awardsData, error: awardsError } = await supabase
           .from('awards')
           .select('*')
@@ -108,6 +108,7 @@ export default function EventEditPage() {
   }, [event_id]);
   
 
+  //編集完了ボタンを押したときの処理
   const handleSaveClick = async () => {
     const { error: eventError } = await supabase
       .from('events')
@@ -131,7 +132,7 @@ export default function EventEditPage() {
       }
 
       const awardsToInsert = event.awards.map((award) => ({
-        event_id,
+        event_id: event_id,
         order_num: award.order_num,
         name: award.name,
       }));

--- a/src/app/events/[event_id]/edit/page.tsx
+++ b/src/app/events/[event_id]/edit/page.tsx
@@ -1,45 +1,50 @@
 "use client";
 
-import { useParams, useRouter } from 'next/navigation';
-import styles from './page.module.css';
-import { useEffect, useState } from 'react';
-import LoadingSpinner from '../../../../components/LoadingSpinner';
-import { supabase } from '@/supabase/supabase';
-import { EventDetail, Award } from '@/types/Event';
+import { useParams, useRouter } from "next/navigation";
+import styles from "./page.module.css";
+import { useEffect, useState } from "react";
+import LoadingSpinner from "../../../../components/LoadingSpinner";
+import { supabase } from "@/supabase/supabase";
+import { EventDetail, Award } from "@/types/Event";
 
 export default function EventEditPage() {
   const params = useParams();
   const router = useRouter();
   const event_id: string = params.event_id as string;
-  
+
   // EventDetail型に基づく初期状態を設定
   const [event, setEvent] = useState<EventDetail>({
     id: null,
-    name: '',
-    date: '',
-    url: '',
-    comment: '',
-    awards: []
+    name: "",
+    date: "",
+    url: "",
+    comment: "",
+    awards: [],
   });
-
   const [loading, setLoading] = useState(true);
 
   // イベント情報のハンドラ
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
     const { id, value } = e.target;
     setEvent((prevEvent) => ({
       ...prevEvent,
-      [id]: value
+      [id]: value,
     }));
   };
 
   // 賞の変更ハンドラ
-  const handleAwardChange = (index: number, field: keyof Award, value: string | null) => {
+  const handleAwardChange = (
+    index: number,
+    field: keyof Award,
+    value: string | null
+  ) => {
     const updatedAwards = event.awards ? [...event.awards] : [];
     updatedAwards[index] = { ...updatedAwards[index], [field]: value };
     setEvent((prevEvent) => ({
       ...prevEvent,
-      awards: updatedAwards
+      awards: updatedAwards,
     }));
   };
 
@@ -49,17 +54,22 @@ export default function EventEditPage() {
       ...prevEvent,
       awards: [
         ...(prevEvent.awards || []),
-        { order_num: (prevEvent.awards?.length + 1).toString(), name: '' }
-      ]
+        { order_num: (prevEvent.awards?.length + 1).toString(), name: "" },
+      ],
     }));
   };
 
   // 賞の削除
   const removeAward = (index: number) => {
-    const updatedAwards = event.awards ? event.awards.filter((_, i) => i !== index) : [];
+    const updatedAwards = event.awards
+      ? event.awards.filter((_, i) => i !== index)
+      : [];
     setEvent((prevEvent) => ({
       ...prevEvent,
-      awards: updatedAwards.map((award, i) => ({ ...award, order_num: (i + 1).toString() }))
+      awards: updatedAwards.map((award, i) => ({
+        ...award,
+        order_num: (i + 1).toString(),
+      })),
     }));
   };
 
@@ -67,12 +77,12 @@ export default function EventEditPage() {
     const fetchEventData = async () => {
       if (event_id) {
         const { data: eventData, error: eventError } = await supabase
-          .from('events')
-          .select('*')
-          .eq('id', event_id)
+          .from("events")
+          .select("*")
+          .eq("id", event_id)
           .single();
         if (eventError) {
-          console.error('Error fetching event data:', eventError);
+          console.error("Error fetching event data:", eventError);
         } else {
           setEvent((prevEvent) => ({
             ...prevEvent,
@@ -80,54 +90,53 @@ export default function EventEditPage() {
             name: eventData.name,
             date: eventData.date,
             url: eventData.url,
-            comment: eventData.comment
+            comment: eventData.comment,
           }));
-        }        
+        }
         //賞のリストを取得
         const { data: awardsData, error: awardsError } = await supabase
-          .from('awards')
-          .select('*')
-          .eq('event_id', event_id)
-          .order('order_num', { ascending: true });//order_numを昇順にソート         
+          .from("awards")
+          .select("*")
+          .eq("event_id", event_id)
+          .order("order_num", { ascending: true }); //order_numを昇順にソート
         if (awardsError) {
-          console.error('Error fetching awards data:', awardsError);
+          console.error("Error fetching awards data:", awardsError);
         } else {
           setEvent((prevEvent) => ({
             ...prevEvent,
             awards: awardsData.map((award: Award) => ({
               order_num: award.order_num,
-              name: award.name
-            }))
+              name: award.name,
+            })),
           }));
         }
         setLoading(false);
       }
     };
-  
+
     fetchEventData();
   }, [event_id]);
-  
 
   //編集完了ボタンを押したときの処理
   const handleSaveClick = async () => {
     const { error: eventError } = await supabase
-      .from('events')
+      .from("events")
       .update({ name: event.name, comment: event.comment, url: event.url })
-      .eq('id', event_id);
+      .eq("id", event_id);
 
     if (eventError) {
-      console.error('イベントの更新中にエラーが発生しました:', eventError);
+      console.error("イベントの更新中にエラーが発生しました:", eventError);
       return;
     }
 
     if (event.awards) {
       const { error: deleteError } = await supabase
-        .from('awards')
+        .from("awards")
         .delete()
-        .eq('event_id', event_id);
+        .eq("event_id", event_id);
 
       if (deleteError) {
-        console.error('賞の削除中にエラーが発生しました:', deleteError);
+        console.error("賞の削除中にエラーが発生しました:", deleteError);
         return;
       }
 
@@ -138,11 +147,11 @@ export default function EventEditPage() {
       }));
 
       const { error: awardError } = await supabase
-        .from('awards')
+        .from("awards")
         .insert(awardsToInsert);
 
       if (awardError) {
-        console.error('賞の追加中にエラーが発生しました:', awardError);
+        console.error("賞の追加中にエラーが発生しました:", awardError);
         return;
       }
     }
@@ -189,7 +198,6 @@ export default function EventEditPage() {
           onChange={handleChange}
         />
 
-  
         <div className={styles.awardsSection}>
           <h2>賞の編集</h2>
           {event.awards?.map((award, index) => (
@@ -197,19 +205,28 @@ export default function EventEditPage() {
               <label className={styles.label}>賞の表示順</label>
               <input
                 type="number"
-                readOnly//編集不可に設定
-                value={award.order_num || ''}
+                readOnly //編集不可に設定
+                value={award.order_num || ""}
                 className={styles.input}
               />
+
+              {/*TODO: 賞の名前が登録されてない場合でも登録できてしまうエラーを修正*/}
+
               <label className={styles.label}>賞の名前</label>
               <input
                 type="text"
                 value={award.name}
-                onChange={(e) => handleAwardChange(index, 'name', e.target.value)}
+                onChange={(e) =>
+                  handleAwardChange(index, "name", e.target.value)
+                }
                 className={styles.input}
                 required
               />
-              <button type="button" onClick={() => removeAward(index)} className={styles.button}>
+              <button
+                type="button"
+                onClick={() => removeAward(index)}
+                className={styles.button}
+              >
                 削除
               </button>
             </div>
@@ -219,7 +236,11 @@ export default function EventEditPage() {
           </button>
         </div>
 
-        <button type="button" className={styles.saveButton} onClick={handleSaveClick}>
+        <button
+          type="button"
+          className={styles.saveButton}
+          onClick={handleSaveClick}
+        >
           編集完了
         </button>
       </div>

--- a/src/app/events/[event_id]/edit/page.tsx
+++ b/src/app/events/[event_id]/edit/page.tsx
@@ -5,21 +5,26 @@ import styles from './page.module.css';
 import { useEffect, useState } from 'react';
 import LoadingSpinner from '../../../../components/LoadingSpinner';
 import { supabase } from '@/supabase/supabase';
-import { EventDetail } from '@/types/Event';
+import { EventDetail, Award } from '@/types/Event';
 
 export default function EventEditPage() {
   const params = useParams();
   const router = useRouter();
   const event_id: string = params.event_id as string;
+  
+  // EventDetail型に基づく初期状態を設定
   const [event, setEvent] = useState<EventDetail>({
     id: null,
     name: '',
     date: '',
     url: '',
-    comment: ''
+    comment: '',
+    awards: []
   });
+
   const [loading, setLoading] = useState(true);
 
+  // イベント情報のハンドラ
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { id, value } = e.target;
     setEvent((prevEvent) => ({
@@ -28,32 +33,121 @@ export default function EventEditPage() {
     }));
   };
 
+  // 賞の変更ハンドラ
+  const handleAwardChange = (index: number, field: keyof Award, value: string | null) => {
+    const updatedAwards = event.awards ? [...event.awards] : [];
+    updatedAwards[index] = { ...updatedAwards[index], [field]: value };
+    setEvent((prevEvent) => ({
+      ...prevEvent,
+      awards: updatedAwards
+    }));
+  };
+
+  // 賞の追加
+  const addAward = () => {
+    setEvent((prevEvent) => ({
+      ...prevEvent,
+      awards: [
+        ...(prevEvent.awards || []),
+        { order_num: (prevEvent.awards?.length + 1).toString(), name: '' }
+      ]
+    }));
+  };
+
+  // 賞の削除
+  const removeAward = (index: number) => {
+    const updatedAwards = event.awards ? event.awards.filter((_, i) => i !== index) : [];
+    setEvent((prevEvent) => ({
+      ...prevEvent,
+      awards: updatedAwards.map((award, i) => ({ ...award, order_num: (i + 1).toString() }))
+    }));
+  };
+
   useEffect(() => {
     const fetchEventData = async () => {
       if (event_id) {
-        const { data, error } = await supabase
+        const { data: eventData, error: eventError } = await supabase
           .from('events')
           .select('*')
           .eq('id', event_id)
           .single();
-
-        if (error) {
-          console.error('Error fetching event data:', error);
+  
+        if (eventError) {
+          console.error('Error fetching event data:', eventError);
         } else {
-          setEvent({
-            id: data.id,
-            name: data.name,
-            date: data.date,
-            url: data.url,
-            comment: data.comment
-          } as EventDetail);
+          setEvent((prevEvent) => ({
+            ...prevEvent,
+            id: eventData.id,
+            name: eventData.name,
+            date: eventData.date,
+            url: eventData.url,
+            comment: eventData.comment
+          }));
+        }        
+        const { data: awardsData, error: awardsError } = await supabase
+          .from('awards')
+          .select('*')
+          .eq('event_id', event_id)
+          .order('order_num', { ascending: true });//order_numを昇順にソート         
+        if (awardsError) {
+          console.error('Error fetching awards data:', awardsError);
+        } else {
+          setEvent((prevEvent) => ({
+            ...prevEvent,
+            awards: awardsData.map((award: Award) => ({
+              order_num: award.order_num,
+              name: award.name
+            }))
+          }));
         }
         setLoading(false);
       }
     };
-
+  
     fetchEventData();
   }, [event_id]);
+  
+
+  const handleSaveClick = async () => {
+    const { error: eventError } = await supabase
+      .from('events')
+      .update({ name: event.name, comment: event.comment, url: event.url })
+      .eq('id', event_id);
+
+    if (eventError) {
+      console.error('イベントの更新中にエラーが発生しました:', eventError);
+      return;
+    }
+
+    if (event.awards) {
+      const { error: deleteError } = await supabase
+        .from('awards')
+        .delete()
+        .eq('event_id', event_id);
+
+      if (deleteError) {
+        console.error('賞の削除中にエラーが発生しました:', deleteError);
+        return;
+      }
+
+      const awardsToInsert = event.awards.map((award) => ({
+        event_id,
+        order_num: award.order_num,
+        name: award.name,
+      }));
+
+      const { error: awardError } = await supabase
+        .from('awards')
+        .insert(awardsToInsert);
+
+      if (awardError) {
+        console.error('賞の追加中にエラーが発生しました:', awardError);
+        return;
+      }
+    }
+
+    router.push(`/events/${event_id}`);
+  };
 
   if (loading) {
     return <LoadingSpinner />;
@@ -63,20 +157,6 @@ export default function EventEditPage() {
     return <p className={styles.notFound}>イベントが見つかりませんでした。</p>;
   }
 
-  const handleSaveClick = async () => {
-    const { error } = await supabase
-      .from('events')
-      .update({ name: event.name, comment: event.comment, url: event.url })
-      .eq('id', event_id);
-
-    if (error) {
-      console.error('Error updating event:', error);
-    } else {
-      console.log('Event updated successfully:', event);
-      router.push(`/events/${event_id}`);
-    }
-  };
-
   return (
     <main className={styles.fullScreen}>
       <div className={styles.container}>
@@ -85,7 +165,7 @@ export default function EventEditPage() {
         <input
           className={styles.input}
           type="text"
-          id="name"  
+          id="name"
           value={event.name}
           onChange={handleChange}
           required
@@ -94,7 +174,7 @@ export default function EventEditPage() {
         <label className={styles.label}>説明</label>
         <textarea
           className={styles.textarea}
-          id="comment"  
+          id="comment"
           value={event.comment}
           onChange={handleChange}
         />
@@ -103,15 +183,42 @@ export default function EventEditPage() {
         <input
           className={styles.input}
           type="text"
-          id="url"  
+          id="url"
           value={event.url}
           onChange={handleChange}
         />
 
-        <button 
-          className={styles.saveButton} 
-          onClick={handleSaveClick}
-        >
+  
+        <div className={styles.awardsSection}>
+          <h2>賞の編集</h2>
+          {event.awards?.map((award, index) => (
+            <div key={index} className={styles.formGroup}>
+              <label className={styles.label}>賞の表示順</label>
+              <input
+                type="number"
+                readOnly//編集不可に設定
+                value={award.order_num || ''}
+                className={styles.input}
+              />
+              <label className={styles.label}>賞の名前</label>
+              <input
+                type="text"
+                value={award.name}
+                onChange={(e) => handleAwardChange(index, 'name', e.target.value)}
+                className={styles.input}
+                required
+              />
+              <button type="button" onClick={() => removeAward(index)} className={styles.button}>
+                削除
+              </button>
+            </div>
+          ))}
+          <button type="button" onClick={addAward} className={styles.button}>
+            賞を追加
+          </button>
+        </div>
+
+        <button type="button" className={styles.saveButton} onClick={handleSaveClick}>
           編集完了
         </button>
       </div>

--- a/src/app/events/[event_id]/page.module.css
+++ b/src/app/events/[event_id]/page.module.css
@@ -73,3 +73,28 @@
     color: #d9534f;
     margin-top: 40px;
 }
+
+.awardsContainer {
+    margin-top: 30px;
+    padding: 20px;
+    background-color: #f7f7f7;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.awardItem {
+    font-size: 1.1rem;
+    color: #333;
+    padding: 12px 15px;
+    margin-bottom: 10px;
+    background-color: #fff;
+    border-left: 4px solid #007bff;
+    border-radius: 6px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    transition: transform 0.2s ease-in-out;
+}
+
+.awardItem:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}

--- a/src/app/events/[event_id]/page.tsx
+++ b/src/app/events/[event_id]/page.tsx
@@ -6,7 +6,8 @@ import styles from "./page.module.css";
 import { useEffect, useState } from "react";
 import LoadingSpinner from "../../../components/LoadingSpinner";
 import { supabase } from "@/supabase/supabase";
-import { EventDetail, Award } from "@/types/Event";
+import { EventDetail } from "@/types/Event";
+import { Award } from "@/types/Award"
 
 export default function EventDetailPage() {
   const params = useParams();

--- a/src/app/events/[event_id]/page.tsx
+++ b/src/app/events/[event_id]/page.tsx
@@ -14,6 +14,7 @@ export default function EventDetailPage() {
   const [event, setEvent] = useState<EventDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const router = useRouter();
+  
   // event_idの変更をトリガーにしてsetEventを実行
   useEffect(() => {
     const fetchEventData = async () => {

--- a/src/app/events/[event_id]/page.tsx
+++ b/src/app/events/[event_id]/page.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { useParams, useRouter } from 'next/navigation';
-import Link from 'next/link';
-import styles from './page.module.css';
-import { useEffect, useState } from 'react';
-import LoadingSpinner from '../../../components/LoadingSpinner';
-import { supabase } from '@/supabase/supabase';
-import { EventDetail, Award } from '@/types/Event';
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import styles from "./page.module.css";
+import { useEffect, useState } from "react";
+import LoadingSpinner from "../../../components/LoadingSpinner";
+import { supabase } from "@/supabase/supabase";
+import { EventDetail, Award } from "@/types/Event";
 
 export default function EventDetailPage() {
   const params = useParams();
@@ -14,30 +14,33 @@ export default function EventDetailPage() {
   const [event, setEvent] = useState<EventDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const router = useRouter();
-  
+
   // event_idの変更をトリガーにしてsetEventを実行
   useEffect(() => {
     const fetchEventData = async () => {
       if (event_id) {
         const { data: eventData, error: eventError } = await supabase
-          .from('events')
-          .select('*')
-          .eq('id', event_id)
+          .from("events")
+          .select("*")
+          .eq("id", event_id)
           .single();
 
         const { data: awardsData, error: awardsError } = await supabase
-          .from('awards')
-          .select('*')
-          .eq('event_id', event_id)
-          .order('order_num', { ascending: true });
+          .from("awards")
+          .select("*")
+          .eq("event_id", event_id)
+          .order("order_num", { ascending: true });
 
         if (eventError || awardsError) {
-          console.error('Error fetching event or awards data:', eventError || awardsError);
+          console.error(
+            "Error fetching event or awards data:",
+            eventError || awardsError
+          );
           setEvent(null);
         } else {
           setEvent({
             ...eventData,
-            awards: awardsData || []
+            awards: awardsData || [],
           } as EventDetail);
         }
         setLoading(false);
@@ -74,10 +77,12 @@ export default function EventDetailPage() {
             ))}
           </div>
         )}
-        <button 
-          onClick={() => router.push(`/events/${event_id}/edit`)} 
+        <button
+          onClick={() => router.push(`/events/${event_id}/edit`)}
           className={styles.editButton}
-          >編集</button>
+        >
+          編集
+        </button>
       </div>
     </main>
   );

--- a/src/app/events/[event_id]/page.tsx
+++ b/src/app/events/[event_id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
 import styles from './page.module.css';
 import { useEffect, useState } from 'react';
@@ -13,7 +13,7 @@ export default function EventDetailPage() {
   const event_id: string = params.event_id as string;
   const [event, setEvent] = useState<EventDetail | null>(null);
   const [loading, setLoading] = useState(true);
-
+  const router = useRouter();
   // event_idの変更をトリガーにしてsetEventを実行
   useEffect(() => {
     const fetchEventData = async () => {
@@ -73,10 +73,10 @@ export default function EventDetailPage() {
             ))}
           </div>
         )}
-
-        <Link href={`/events/${event_id}/edit`} className={styles.editButton}>
-          編集
-        </Link>
+        <button 
+          onClick={() => router.push(`/events/${event_id}/edit`)} 
+          className={styles.editButton}
+          >編集</button>
       </div>
     </main>
   );

--- a/src/app/events/[event_id]/page.tsx
+++ b/src/app/events/[event_id]/page.tsx
@@ -6,8 +6,7 @@ import styles from './page.module.css';
 import { useEffect, useState } from 'react';
 import LoadingSpinner from '../../../components/LoadingSpinner';
 import { supabase } from '@/supabase/supabase';
-import { EventDetail } from '@/types/Event';
-
+import { EventDetail, Award } from '@/types/Event';
 
 export default function EventDetailPage() {
   const params = useParams();
@@ -19,18 +18,26 @@ export default function EventDetailPage() {
   useEffect(() => {
     const fetchEventData = async () => {
       if (event_id) {
-        const { data, error } = await supabase
+        const { data: eventData, error: eventError } = await supabase
           .from('events')
           .select('*')
           .eq('id', event_id)
           .single();
-        
-        //データ取得時のエラーハンドリング
-        if (error) {
-          console.error('Error fetching event data:', error);
+
+        const { data: awardsData, error: awardsError } = await supabase
+          .from('awards')
+          .select('*')
+          .eq('event_id', event_id)
+          .order('order_num', { ascending: true });
+
+        if (eventError || awardsError) {
+          console.error('Error fetching event or awards data:', eventError || awardsError);
           setEvent(null);
         } else {
-          setEvent(data as EventDetail);
+          setEvent({
+            ...eventData,
+            awards: awardsData || []
+          } as EventDetail);
         }
         setLoading(false);
       }
@@ -39,17 +46,14 @@ export default function EventDetailPage() {
     fetchEventData();
   }, [event_id]);
 
-  
   if (loading) {
     return <LoadingSpinner />;
   }
-  
-  //(DBに登録されていないeventの詳細を見ようとした場合(event_id = 5を取得しようとした場合))
+
   if (!event) {
     return <p className={styles.notFound}>イベントが見つかりませんでした。</p>;
   }
 
-  // イベントが正常に処理された場合の処理（イベント詳細を記述）
   return (
     <main className={styles.fullScreen}>
       <div className={styles.container}>
@@ -57,6 +61,19 @@ export default function EventDetailPage() {
         <p className={styles.description}>{event.comment}</p>
         <p className={styles.details}>開催日: {event.date}</p>
         <p className={styles.details}>URL: {event.url}</p>
+
+        {/* 賞のリストを表示 */}
+        {event.awards && event.awards.length > 0 && (
+          <div className={styles.awardsContainer}>
+            <h2 className={styles.title}>賞一覧</h2>
+            {event.awards.map((award: Award, index: number) => (
+              <div key={index} className={styles.awardItem}>
+                {award.order_num}. {award.name}
+              </div>
+            ))}
+          </div>
+        )}
+
         <Link href={`/events/${event_id}/edit`} className={styles.editButton}>
           編集
         </Link>

--- a/src/app/events/new/page.module.css
+++ b/src/app/events/new/page.module.css
@@ -8,6 +8,7 @@
     padding: 20px;
     box-sizing: border-box;
     text-align: center; /* テキストを中央揃え */
+    margin-top: 40px; 
   }
   
   .title {
@@ -54,6 +55,7 @@
     font-size: 1rem;
     cursor: pointer;
     transition: background-color 0.3s ease;
+    margin-top: 10px;
   }
   
   .button:hover {

--- a/src/app/events/new/page.module.css
+++ b/src/app/events/new/page.module.css
@@ -1,91 +1,99 @@
 .container {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    height: 100vh; /* ビューポートの高さ全体を使用 */
-    background-color: #f7f9fc; /* 背景色を薄いグレーに */
-    padding: 20px;
-    box-sizing: border-box;
-    text-align: center; /* テキストを中央揃え */
-    margin-top: 40px; 
-  }
-  
-  .title {
-    margin-bottom: 30px;
-    color: #333;
-    font-size: 2rem;
-    font-weight: bold;
-  }
-  
-  .form {
-    background-color: #fff;
-    padding: 20px;
-    border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    width: 100%;
-    max-width: 500px;
-  }
-  
-  .formGroup {
-    margin-bottom: 20px;
-    text-align: left;
-  }
-  
-  .label {
-    display: block;
-    margin-bottom: 5px;
-    font-weight: bold;
-  }
-  
-  .input, .textarea {
-    width: 100%;
-    padding: 10px;
-    border: 1px solid #ddd;
-    border-radius: 4px;
-    font-size: 1rem;
-  }
-  
-  .button {
-    background-color: #007bff; /* ボタンの背景色をリンクと同じ青に設定 */
-    color: white;
-    border: none;
-    padding: 10px 20px;
-    border-radius: 4px;
-    font-size: 1rem;
-    cursor: pointer;
-    transition: background-color 0.3s ease;
-    margin-top: 10px;
-  }
-  
-  .button:hover {
-    background-color: #0056b3; /* ホバー時の背景色を暗めに設定 */
-  }
-  
-  .submittedData {
-    margin-top: 30px;
-    text-align: left;
-    width: 100%;
-    max-width: 500px;
-    background-color: #fff;
-    padding: 20px;
-    border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  }
-  
-  .submittedData h2 {
-    margin-bottom: 15px;
-    color: #333;
-    font-size: 1.5rem;
-    font-weight: bold;
-  }
-  
-  .submittedData p {
-    margin: 5px 0;
-    font-size: 1rem;
-    color: #555;
-  }
-  
-  .submittedData strong {
-    color: #000;
-  }
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start; /* Center alignment adjusted for scrollable content */
+  align-items: center;
+  height: 100vh;
+  background-color: #f7f9fc;
+  padding: 20px;
+  box-sizing: border-box;
+  text-align: center;
+  overflow-y: auto; /* Allow vertical scrolling */
+}
+
+.title {
+  margin-bottom: 30px;
+  color: #333;
+  font-size: 2rem;
+  font-weight: bold;
+}
+
+.form {
+  background-color: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  width: 100%;
+  max-width: 500px;
+  max-height: 80vh; /* Limit form height */
+  overflow-y: auto; /* Allow scrolling within the form */
+}
+
+.formGroup {
+  margin-bottom: 20px;
+  text-align: left;
+}
+
+.label {
+  display: block;
+  margin-bottom: 5px;
+  font-weight: bold;
+}
+
+.input, .textarea {
+  width: 100%;
+  padding: 10px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 1rem;
+}
+
+.button {
+  background-color: #007bff;
+  color: white;
+  border: none;
+  padding: 10px 20px;
+  border-radius: 4px;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+  margin-top: 10px;
+}
+
+.button:hover {
+  background-color: #0056b3;
+}
+
+.awardsSection {
+  max-height: 200px; /* Limit height of awards section */
+  overflow-y: auto; /* Enable scrolling for awards */
+  margin-bottom: 20px;
+}
+
+.submittedData {
+  margin-top: 30px;
+  text-align: left;
+  width: 100%;
+  max-width: 500px;
+  background-color: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.submittedData h2 {
+  margin-bottom: 15px;
+  color: #333;
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+.submittedData p {
+  margin: 5px 0;
+  font-size: 1rem;
+  color: #555;
+}
+
+.submittedData strong {
+  color: #000;
+}

--- a/src/app/events/new/page.tsx
+++ b/src/app/events/new/page.tsx
@@ -4,11 +4,11 @@ import React, { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import styles from './page.module.css';
 import { supabase } from '@/supabase/supabase';
-import { EventDetail } from '@/types/Event';
+import { EventDetail, Award } from '@/types/Event';
 
 const NewEventPage: React.FC = () => {
   const router = useRouter();
-  
+
   // EventDetail型に基づく初期状態を設定
   const [event, setEvent] = useState<EventDetail>({
     id: null, 
@@ -16,14 +16,15 @@ const NewEventPage: React.FC = () => {
     date: '',
     url: '',
     comment: '',
-    awards: [{order_num: null, name: ''}]
+    awards: [{ order_num: '1', name: '' }]
   });
-  
+
   // 登録完了状態管理
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+  // イベント情報のハンドラ
+  const handleEventChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { id, value } = e.target;
     setEvent((prevEvent) => ({
       ...prevEvent,
@@ -31,33 +32,86 @@ const NewEventPage: React.FC = () => {
     }));
   };
 
+  // 賞の変更ハンドラ, index(awards配列のindex指定), field(そのindexの中で要素を指定), value(その要素の変更内容を指定)
+  const handleAwardChange = (index: number, field: keyof Award, value: string | null) => {
+    const updatedAwards = event.awards ? [...event.awards] : [];
+    updatedAwards[index] = { ...updatedAwards[index], [field]: value };
+    setEvent((prevEvent) => ({
+      ...prevEvent,
+      awards: updatedAwards
+    }));
+  };
+
+  // 賞の追加
+
+  const addAward = () => {
+    setEvent((prevEvent) => ({
+      ...prevEvent,
+      awards: [
+        ...(prevEvent.awards || []),
+        { order_num: (prevEvent.awards?.length + 1).toString(), name: '' } // 新しい賞に次の順番を割り当て
+      ]
+    }));
+  };
+  
+  // 賞の削除
+  const removeAward = (index: number) => {
+    const updatedAwards = event.awards ? event.awards.filter((_, i) => i !== index) : [];
+    setEvent((prevEvent) => ({
+      ...prevEvent,
+      awards: updatedAwards.map((award, i) => ({ ...award, order_num: (i + 1).toString() })) // 削除後、順番を繰り上げる(iを基準にすることで要素数からorder_numをもとめる)
+    }));
+};
+
+
+  // フォームの送信ハンドラ
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
     setError(null);
 
-    const { data, error } = await supabase
+    // eventsテーブルへの登録
+    const { data: eventData, error: eventError } = await supabase
       .from('events')
       .insert([{ 
         name: event.name, 
         date: event.date, 
         url: event.url, 
         comment: event.comment 
-      }]);
+      }])
+      .select()
+      .single();
 
-    if (error) {
-      console.error('Error inserting event:', error);
+    if (eventError || !eventData) {
+      console.error('Error inserting event:', eventError);
       setError('イベントの追加に失敗しました。');
       setLoading(false);
-    } else {
-      console.log('Event added successfully:', data);
-      // 追加成功後にイベント一覧ページに遷移
-      router.push('/events');
+      return;
     }
+
+    // awardsテーブルへの登録
+    if (event.awards && event.awards.length > 0) {
+      const awardsToInsert = event.awards.map((award) => ({
+        event_id: eventData.id,
+        order_num: award.order_num,
+        name: award.name
+      }));
+
+      const { error: awardError } = await supabase
+        .from('awards')
+        .insert(awardsToInsert);
+
+      if (awardError) {
+        console.error('Error inserting awards:', awardError);
+        setError('賞の追加に失敗しました。');
+        setLoading(false);
+        return;
+      }
+    }
+
+    // 追加成功後にイベント一覧ページに遷移
+    router.push('/events');
   };
-
-
-
 
   return (
     <main className={styles.container}>
@@ -69,7 +123,7 @@ const NewEventPage: React.FC = () => {
             type="text"
             id="name"
             value={event.name}
-            onChange={handleChange}
+            onChange={handleEventChange}
             className={styles.input}
             required
           />
@@ -80,18 +134,18 @@ const NewEventPage: React.FC = () => {
             type="date"
             id="date"
             value={event.date}
-            onChange={handleChange}
+            onChange={handleEventChange}
             className={styles.input}
             required
           />
         </div>
         <div className={styles.formGroup}>
-          <label htmlFor="関連url" className={styles.label}>URL</label>
+          <label htmlFor="url" className={styles.label}>関連URL</label>
           <input
             type="url"
             id="url"
             value={event.url}
-            onChange={handleChange}
+            onChange={handleEventChange}
             className={styles.input}
           />
         </div>
@@ -100,10 +154,44 @@ const NewEventPage: React.FC = () => {
           <textarea
             id="comment"
             value={event.comment}
-            onChange={handleChange}
+            onChange={handleEventChange}
             className={styles.textarea}
           />
         </div>
+
+        {/* 賞の登録フォーム */}
+        <div className={styles.awardsSection}>
+          <h2>賞の登録</h2>
+          {event.awards?.map((award, index) => (
+            <div key={index} className={styles.formGroup}>
+              <label className={styles.label}>賞の表示順
+              </label>
+              <input
+                type="number"
+                readOnly
+                value={award.order_num || ''}
+                onChange={(e) => handleAwardChange(index, 'order_num', e.target.value ? e.target.value : null)}
+                className={styles.input}
+                required
+              />
+              <label className={styles.label}>賞の名前</label>
+              <input
+                type="text"
+                value={award.name}
+                onChange={(e) => handleAwardChange(index, 'name', e.target.value)}
+                className={styles.input}
+                required
+              />
+              <button type="button" onClick={() => removeAward(index)} className={styles.button}>
+                削除
+              </button>
+            </div>
+          ))}
+          <button type="button" onClick={addAward} className={styles.button}>
+            賞を追加
+          </button>
+        </div>
+
         <button type="submit" className={styles.button} disabled={loading}>
           {loading ? '保存中...' : '完了'}
         </button>

--- a/src/app/events/new/page.tsx
+++ b/src/app/events/new/page.tsx
@@ -4,7 +4,8 @@ import React, { useState } from "react";
 import { useRouter } from "next/navigation";
 import styles from "./page.module.css";
 import { supabase } from "@/supabase/supabase";
-import { EventDetail, Award } from "@/types/Event";
+import { EventDetail } from "@/types/Event";
+import { Award } from "@/types/Award"
 
 const NewEventPage: React.FC = () => {
   const router = useRouter();

--- a/src/app/events/new/page.tsx
+++ b/src/app/events/new/page.tsx
@@ -15,7 +15,8 @@ const NewEventPage: React.FC = () => {
     name: '',
     date: '',
     url: '',
-    comment: ''
+    comment: '',
+    awards: [{order_num: null, name: ''}]
   });
   
   // 登録完了状態管理
@@ -54,6 +55,9 @@ const NewEventPage: React.FC = () => {
       router.push('/events');
     }
   };
+
+
+
 
   return (
     <main className={styles.container}>

--- a/src/app/events/new/page.tsx
+++ b/src/app/events/new/page.tsx
@@ -60,7 +60,7 @@ const NewEventPage: React.FC = () => {
       ...prevEvent,
       awards: updatedAwards.map((award, i) => ({ ...award, order_num: (i + 1).toString() })) // 削除後、順番を繰り上げる(iを基準にすることで要素数からorder_numをもとめる)
     }));
-};
+  };
 
 
   //イベントの新規登録時の処理
@@ -163,8 +163,7 @@ const NewEventPage: React.FC = () => {
           <h2>賞の登録</h2>
           {event.awards?.map((award, index) => (
             <div key={index} className={styles.formGroup}>
-              <label className={styles.label}>賞の表示順
-              </label>
+              <label className={styles.label}>賞の表示順</label>
               <input
                 type="number"
                 readOnly

--- a/src/app/events/new/page.tsx
+++ b/src/app/events/new/page.tsx
@@ -1,44 +1,49 @@
 "use client";
 
-import React, { useState } from 'react';
-import { useRouter } from 'next/navigation';
-import styles from './page.module.css';
-import { supabase } from '@/supabase/supabase';
-import { EventDetail, Award } from '@/types/Event';
+import React, { useState } from "react";
+import { useRouter } from "next/navigation";
+import styles from "./page.module.css";
+import { supabase } from "@/supabase/supabase";
+import { EventDetail, Award } from "@/types/Event";
 
 const NewEventPage: React.FC = () => {
   const router = useRouter();
 
   // EventDetail型に基づく初期状態を設定
   const [event, setEvent] = useState<EventDetail>({
-    id: null, 
-    name: '',
-    date: '',
-    url: '',
-    comment: '',
-    awards: [{ order_num: '1', name: '' }]
+    id: null,
+    name: "",
+    date: "",
+    url: "",
+    comment: "",
+    awards: [{ order_num: "1", name: "" }],
   });
-
   // 登録完了状態管理
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   // イベント情報のハンドラ
-  const handleEventChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+  const handleEventChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
     const { id, value } = e.target;
     setEvent((prevEvent) => ({
       ...prevEvent,
-      [id]: value
+      [id]: value,
     }));
   };
 
   // 賞の変更ハンドラ, index(awards配列のindex指定), field(そのindexの中で要素を指定), value(その要素の変更内容を指定)
-  const handleAwardChange = (index: number, field: keyof Award, value: string | null) => {
+  const handleAwardChange = (
+    index: number,
+    field: keyof Award,
+    value: string | null
+  ) => {
     const updatedAwards = event.awards ? [...event.awards] : [];
     updatedAwards[index] = { ...updatedAwards[index], [field]: value };
     setEvent((prevEvent) => ({
       ...prevEvent,
-      awards: updatedAwards
+      awards: updatedAwards,
     }));
   };
 
@@ -48,20 +53,24 @@ const NewEventPage: React.FC = () => {
       ...prevEvent,
       awards: [
         ...(prevEvent.awards || []),
-        { order_num: (prevEvent.awards?.length + 1).toString(), name: '' } // 新しい賞に次の順番を割り当て
-      ]
-    }));
-  };
-  
-  // 賞の削除
-  const removeAward = (index: number) => {
-    const updatedAwards = event.awards ? event.awards.filter((_, i) => i !== index) : [];
-    setEvent((prevEvent) => ({
-      ...prevEvent,
-      awards: updatedAwards.map((award, i) => ({ ...award, order_num: (i + 1).toString() })) // 削除後、順番を繰り上げる(iを基準にすることで要素数からorder_numをもとめる)
+        { order_num: (prevEvent.awards?.length + 1).toString(), name: "" }, // 新しい賞に次の順番を割り当て
+      ],
     }));
   };
 
+  // 賞の削除
+  const removeAward = (index: number) => {
+    const updatedAwards = event.awards
+      ? event.awards.filter((_, i) => i !== index)
+      : [];
+    setEvent((prevEvent) => ({
+      ...prevEvent,
+      awards: updatedAwards.map((award, i) => ({
+        ...award,
+        order_num: (i + 1).toString(),
+      })), // 削除後、順番を繰り上げる(iを基準にすることで要素数からorder_numをもとめる)
+    }));
+  };
 
   //イベントの新規登録時の処理
   const handleSubmit = async (e: React.FormEvent) => {
@@ -71,19 +80,21 @@ const NewEventPage: React.FC = () => {
 
     // eventsテーブルへの登録
     const { data: eventData, error: eventError } = await supabase
-      .from('events')
-      .insert([{ 
-        name: event.name, 
-        date: event.date, 
-        url: event.url, 
-        comment: event.comment 
-      }])
+      .from("events")
+      .insert([
+        {
+          name: event.name,
+          date: event.date,
+          url: event.url,
+          comment: event.comment,
+        },
+      ])
       .select()
       .single();
 
     if (eventError || !eventData) {
-      console.error('Error inserting event:', eventError);
-      setError('イベントの追加に失敗しました。');
+      console.error("Error inserting event:", eventError);
+      setError("イベントの追加に失敗しました。");
       setLoading(false);
       return;
     }
@@ -93,23 +104,23 @@ const NewEventPage: React.FC = () => {
       const awardsToInsert = event.awards.map((award) => ({
         event_id: eventData.id,
         order_num: award.order_num,
-        name: award.name
+        name: award.name,
       }));
 
       const { error: awardError } = await supabase
-        .from('awards')
+        .from("awards")
         .insert(awardsToInsert);
 
       if (awardError) {
-        console.error('Error inserting awards:', awardError);
-        setError('賞の追加に失敗しました。');
+        console.error("Error inserting awards:", awardError);
+        setError("賞の追加に失敗しました。");
         setLoading(false);
         return;
       }
     }
 
     // 追加成功後にイベント一覧ページに遷移
-    router.push('/events');
+    router.push("/events");
   };
 
   return (
@@ -117,7 +128,9 @@ const NewEventPage: React.FC = () => {
       <h1 className={styles.title}>新規イベント作成</h1>
       <form onSubmit={handleSubmit} className={styles.form}>
         <div className={styles.formGroup}>
-          <label htmlFor="name" className={styles.label}>イベント名</label>
+          <label htmlFor="name" className={styles.label}>
+            イベント名
+          </label>
           <input
             type="text"
             id="name"
@@ -128,7 +141,9 @@ const NewEventPage: React.FC = () => {
           />
         </div>
         <div className={styles.formGroup}>
-          <label htmlFor="date" className={styles.label}>開催日</label>
+          <label htmlFor="date" className={styles.label}>
+            開催日
+          </label>
           <input
             type="date"
             id="date"
@@ -139,7 +154,9 @@ const NewEventPage: React.FC = () => {
           />
         </div>
         <div className={styles.formGroup}>
-          <label htmlFor="url" className={styles.label}>関連URL</label>
+          <label htmlFor="url" className={styles.label}>
+            関連URL
+          </label>
           <input
             type="url"
             id="url"
@@ -149,7 +166,9 @@ const NewEventPage: React.FC = () => {
           />
         </div>
         <div className={styles.formGroup}>
-          <label htmlFor="comment" className={styles.label}>コメント</label>
+          <label htmlFor="comment" className={styles.label}>
+            コメント
+          </label>
           <textarea
             id="comment"
             value={event.comment}
@@ -167,8 +186,14 @@ const NewEventPage: React.FC = () => {
               <input
                 type="number"
                 readOnly
-                value={award.order_num || ''}
-                onChange={(e) => handleAwardChange(index, 'order_num', e.target.value ? e.target.value : null)}
+                value={award.order_num || ""}
+                onChange={(e) =>
+                  handleAwardChange(
+                    index,
+                    "order_num",
+                    e.target.value ? e.target.value : null
+                  )
+                }
                 className={styles.input}
                 required
               />
@@ -176,11 +201,17 @@ const NewEventPage: React.FC = () => {
               <input
                 type="text"
                 value={award.name}
-                onChange={(e) => handleAwardChange(index, 'name', e.target.value)}
+                onChange={(e) =>
+                  handleAwardChange(index, "name", e.target.value)
+                }
                 className={styles.input}
                 required
               />
-              <button type="button" onClick={() => removeAward(index)} className={styles.button}>
+              <button
+                type="button"
+                onClick={() => removeAward(index)}
+                className={styles.button}
+              >
                 削除
               </button>
             </div>
@@ -191,7 +222,7 @@ const NewEventPage: React.FC = () => {
         </div>
 
         <button type="submit" className={styles.button} disabled={loading}>
-          {loading ? '保存中...' : '完了'}
+          {loading ? "保存中..." : "完了"}
         </button>
         {error && <p className={styles.error}>{error}</p>}
       </form>

--- a/src/app/events/new/page.tsx
+++ b/src/app/events/new/page.tsx
@@ -43,7 +43,6 @@ const NewEventPage: React.FC = () => {
   };
 
   // 賞の追加
-
   const addAward = () => {
     setEvent((prevEvent) => ({
       ...prevEvent,
@@ -64,7 +63,7 @@ const NewEventPage: React.FC = () => {
 };
 
 
-  // フォームの送信ハンドラ
+  //イベントの新規登録時の処理
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -1,11 +1,11 @@
-"use client"
+"use client";
 
-import React, { useEffect, useState } from 'react';
-import Link from 'next/link';
-import styles from './Page.module.css';
-import EventCard from '../../components/EventCard'; 
-import { supabase } from '../../supabase/supabase';
-import { Event } from '../../types/Event';
+import React, { useEffect, useState } from "react";
+import Link from "next/link";
+import styles from "./Page.module.css";
+import EventCard from "../../components/EventCard";
+import { supabase } from "../../supabase/supabase";
+import { Event } from "../../types/Event";
 
 const EventPage: React.FC = () => {
   const [events, setEvents] = useState<Event[]>([]);
@@ -13,31 +13,28 @@ const EventPage: React.FC = () => {
   useEffect(() => {
     const fetchEvents = async () => {
       const { data, error } = await supabase
-        .from('events')
-        .select('id, name, date, comment') 
-        .order('id', { ascending: true }); // 'id'で昇順にソート
-  
+        .from("events")
+        .select("id, name, date, comment")
+        .order("id", { ascending: true }); // 'id'で昇順にソート
+
       //取得に関するエラーハンドリング
       if (error) {
-        console.error('Error fetching events:', error);
+        console.error("Error fetching events:", error);
       } else {
-        console.log('Fetched data:', data); // デバッグ用に取得データを出力
-        setEvents(data as Event[] || []); // データがnullのときの対策として空配列を設定
+        console.log("Fetched data:", data); // デバッグ用に取得データを出力
+        setEvents((data as Event[]) || []); // データがnullのときの対策として空配列を設定
       }
-
     };
-  
+
     fetchEvents();
   }, []);
-  
-
 
   return (
     <main className={styles.pageHeader}>
       <h1>これはイベント一覧ページです</h1>
-      {events.map((event) => (       
+      {events.map((event) => (
         <EventCard key={event.id} event={event} />
-       ))}
+      ))}
       <Link href="/events/new" className={styles.newEventButton}>
         新規作成
       </Link>
@@ -46,4 +43,3 @@ const EventPage: React.FC = () => {
 };
 
 export default EventPage;
-

--- a/src/types/Award.ts
+++ b/src/types/Award.ts
@@ -1,0 +1,6 @@
+
+//賞に関する型定義
+export interface Award {
+    order_num: string | null;
+    name: string;
+}

--- a/src/types/Event.ts
+++ b/src/types/Event.ts
@@ -8,5 +8,13 @@ export interface Event {
 
 //Event詳細ページで利用する型定義
 export interface EventDetail extends Event{
-    url?: string
+    url?: string;
+    awards: Award[];
+}
+
+
+//賞に関する型定義
+export interface Award {
+    order_num: string | null;
+    name: string;
 }

--- a/src/types/Event.ts
+++ b/src/types/Event.ts
@@ -1,20 +1,15 @@
+import { Award } from ".//Award";
+
 //Event一覧ページで利用する型定義
 export interface Event {
-    id: string | null; 
-    name: string;
-    date?: string;
-    comment?: string;
+  id: string | null;
+  name: string;
+  date?: string;
+  comment?: string;
 }
 
 //Event詳細ページで利用する型定義
-export interface EventDetail extends Event{
-    url?: string;
-    awards: Award[];
-}
-
-
-//賞に関する型定義
-export interface Award {
-    order_num: string | null;
-    name: string;
+export interface EventDetail extends Event {
+  url?: string;
+  awards: Award[];
 }


### PR DESCRIPTION
## 実装内容
   - イベント新規登録ページで賞を登録できるようにした
   - イベント編集ページで賞を編集できるようにした
   - イベント詳細ページで賞に関する情報を閲覧できるようにした
   - 賞に関する型定義の追加
   - supabaseのawardsテーブルのpolicyを追加
## 関連issue
   - #34 
## 結果画像
 - イベント詳細ページ(変更前)
   <img src="https://github.com/user-attachments/assets/e814ff32-1005-4b38-9e4f-c182e1b07cfc" width="250">

- イベント編集ページ(ハーゲンダッツ賞を削除時)
  <img src="https://github.com/user-attachments/assets/8ccb0a44-917a-4bd5-9561-43b7ae9998b3" width="250">

- イベント編集ページ(アイスクリーム賞を追加時)
  <img src="https://github.com/user-attachments/assets/2962bbf6-7fb0-4fc9-8082-3c5b85491f70" width="250">

- イベント新規登録画面
  <img src="https://github.com/user-attachments/assets/c732e22f-4a7a-4db4-955b-e7d96f8d8380" width="250">

## 特にみて欲しい部分
   - イベント編集画面、新規登録画面で賞を登録するとき、バグが発生しないように賞の表示順が登録者によって打ち込めないようになっています。賞を削除するとき、それまでに登録された賞の一番後ろに賞を追加するときは特に問題ないんですけど、すでに賞が登録された状態で表示順が1(order_num=1)の場所に登録しようとした場合とかに少しめんどくさい作業をする必要があります。(少しめんどくさい作業があるだけで普通に使えますが)この部分についてはのちのち変更が必要かもです。
## 今回作れなかった部分
   - 上に書いた内容です
## 補足
   - 