### PR TITLE
Feature/add element location

### DIFF
--- a/src/app/admin/events/existing-events/[event_id]/edit/page.tsx
+++ b/src/app/admin/events/existing-events/[event_id]/edit/page.tsx
@@ -23,6 +23,7 @@ export default function EventEditPage({
     date: "",
     url: "",
     comment: "",
+    location: "",
     awards: [],
   });
   const [loading, setLoading] = useState(true);
@@ -95,6 +96,7 @@ export default function EventEditPage({
             date: eventData.date,
             url: eventData.url,
             comment: eventData.comment,
+            location: eventData.location,
           }));
         }
         //賞のリストを取得
@@ -125,7 +127,12 @@ export default function EventEditPage({
   const handleSaveClick = async () => {
     const { error: eventError } = await supabase
       .from("events")
-      .update({ name: event.name, comment: event.comment, url: event.url })
+      .update({
+        name: event.name,
+        comment: event.comment,
+        url: event.url,
+        location: event.location,
+      })
       .eq("id", eventID);
 
     if (eventError) {
@@ -199,6 +206,15 @@ export default function EventEditPage({
           type="text"
           id="url"
           value={event.url}
+          onChange={handleChange}
+        />
+
+        <label className={styles.label}>開催場所</label>
+        <input
+          className={styles.input}
+          type="text"
+          id="location"
+          value={event.location}
           onChange={handleChange}
         />
 

--- a/src/app/admin/events/new/page.tsx
+++ b/src/app/admin/events/new/page.tsx
@@ -17,6 +17,7 @@ const NewEventPage: React.FC = () => {
     date: "",
     url: "",
     comment: "",
+    location: "",
     awards: [{ order_num: "1", name: "" }],
   });
   // 登録完了状態管理
@@ -88,6 +89,7 @@ const NewEventPage: React.FC = () => {
           date: event.date,
           url: event.url,
           comment: event.comment,
+          location: event.location,
         },
       ])
       .select()
@@ -173,6 +175,17 @@ const NewEventPage: React.FC = () => {
           <textarea
             id="comment"
             value={event.comment}
+            onChange={handleEventChange}
+            className={styles.textarea}
+          />
+        </div>
+        <div className={styles.formGroup}>
+          <label htmlFor="location" className={styles.label}>
+            開催場所
+          </label>
+          <textarea
+            id="location"
+            value={event.location}
             onChange={handleEventChange}
             className={styles.textarea}
           />

--- a/src/app/events/[event_id]/page.tsx
+++ b/src/app/events/[event_id]/page.tsx
@@ -69,6 +69,7 @@ export default function EventDetailPage({
         <p className={styles.description}>{event.comment}</p>
         <p className={styles.details}>開催日: {event.date}</p>
         <p className={styles.details}>URL: {event.url}</p>
+        <p className={styles.details}>開催場所: {event.location}</p>
 
         {/* 賞のリストを表示 */}
         {event.awards && event.awards.length > 0 && (

--- a/src/types/Event.ts
+++ b/src/types/Event.ts
@@ -11,5 +11,6 @@ export interface Event {
 //Event詳細ページで利用する型定義
 export interface EventDetail extends Event {
   url?: string;
+  location?: string;
   awards: Award[];
 }


### PR DESCRIPTION
## 実装内容
   - イベントについてlocationの要素を追加しました
## 関連issue
   - #38 
## 結果画像
- 一般ユーザ・イベント詳細ページ
<img src="https://github.com/user-attachments/assets/76ca9ab6-9562-4a19-b30e-5dc75fac453f" width="250">

- watnowユーザ・イベント新規イベント登録ページ
<img src="https://github.com/user-attachments/assets/f9d5831e-6822-4453-a062-84d7094889a2" width="250">

-  watnowユーザ・既存イベント編集ページ
<img src="https://github.com/user-attachments/assets/cde89a9c-ce4b-4be4-b963-4b1cab8e3cce" width="250">




## 特にみて欲しい部分
   - 特になし
## 今回作れなかった部分
   - 特になし
## 補足
   - locationはオプショナルな要素として定義してあります