### PR TITLE
Headerの作成(デザインを当てる)

### DIFF
--- a/public/paper_airplane.svg
+++ b/public/paper_airplane.svg
@@ -1,0 +1,4 @@
+<svg width="56" height="49" viewBox="0 0 56 49" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M18.9805 19.6355L9.31807 11.4916L53.6911 12.3003L27.5483 44.9738L25.776 24.9146" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M33.196 21.5562L25.7924 24.9017" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,78 +1,3 @@
-:root {
-  --max-width: 1100px;
-  --border-radius: 12px;
-  --font-mono: ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono",
-    "Roboto Mono", "Oxygen Mono", "Ubuntu Monospace", "Source Code Pro",
-    "Fira Mono", "Droid Sans Mono", "Courier New", monospace;
-
-  --foreground-rgb: 0, 0, 0;
-  --background-start-rgb: 214, 219, 220;
-  --background-end-rgb: 255, 255, 255;
-
-  --primary-glow: conic-gradient(
-    from 180deg at 50% 50%,
-    #16abff33 0deg,
-    #0885ff33 55deg,
-    #54d6ff33 120deg,
-    #0071ff33 160deg,
-    transparent 360deg
-  );
-  --secondary-glow: radial-gradient(
-    rgba(255, 255, 255, 1),
-    rgba(255, 255, 255, 0)
-  );
-
-  --tile-start-rgb: 239, 245, 249;
-  --tile-end-rgb: 228, 232, 233;
-  --tile-border: conic-gradient(
-    #00000080,
-    #00000040,
-    #00000030,
-    #00000020,
-    #00000010,
-    #00000010,
-    #00000080
-  );
-
-  --callout-rgb: 238, 240, 241;
-  --callout-border-rgb: 172, 175, 176;
-  --card-rgb: 180, 185, 188;
-  --card-border-rgb: 131, 134, 135;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --foreground-rgb: 255, 255, 255;
-    --background-start-rgb: 0, 0, 0;
-    --background-end-rgb: 0, 0, 0;
-
-    --primary-glow: radial-gradient(rgba(1, 65, 255, 0.4), rgba(1, 65, 255, 0));
-    --secondary-glow: linear-gradient(
-      to bottom right,
-      rgba(1, 65, 255, 0),
-      rgba(1, 65, 255, 0),
-      rgba(1, 65, 255, 0.3)
-    );
-
-    --tile-start-rgb: 2, 13, 46;
-    --tile-end-rgb: 2, 5, 19;
-    --tile-border: conic-gradient(
-      #ffffff80,
-      #ffffff40,
-      #ffffff30,
-      #ffffff20,
-      #ffffff10,
-      #ffffff10,
-      #ffffff80
-    );
-
-    --callout-rgb: 20, 20, 20;
-    --callout-border-rgb: 108, 108, 108;
-    --card-rgb: 100, 100, 100;
-    --card-border-rgb: 200, 200, 200;
-  }
-}
-
 * {
   box-sizing: border-box;
   padding: 0;
@@ -81,6 +6,7 @@
 
 html,
 body {
+  background-color: #FAFBFB;
   max-width: 100vw;
   overflow-x: hidden;
 }
@@ -94,6 +20,10 @@ body {
     )
     rgb(var(--background-start-rgb));
     font-family: 'HannariMincho', sans-serif !important;
+}
+
+main {
+  margin-top: 160px;
 }
 
 a {

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Link from "next/link";
 import styles from "./Page.module.css";
 import Header from "@/components/Header";
+import { HeaderMode } from "@/types/HeaderMode";
 
 const Home: React.FC = () => {
   const services = [
@@ -10,10 +11,25 @@ const Home: React.FC = () => {
     { id: "3", name: "service3" },
     { id: "4", name: "service4" },
     { id: "5", name: "service5" },
+    { id: "6", name: "service6" },
+    { id: "7", name: "service7" },
+    { id: "8", name: "service8" },
+    { id: "9", name: "service9" },
+    { id: "10", name: "service10" },
+    { id: "11", name: "service11" },
+    { id: "12", name: "service12" },
+    { id: "13", name: "service13" },
+    { id: "14", name: "service14" },
+    { id: "15", name: "service15" },
+    { id: "16", name: "service16" },
+    { id: "17", name: "service17" },
+    { id: "18", name: "service18" },
+    { id: "19", name: "service19" },
+    { id: "20", name: "service20" },
   ];
   return (
-    <div className={styles.pageHeader}>
-      <Header />
+    <main>
+      <Header mode={HeaderMode.SERVICES} />
 
       <ul className={styles.serviceList}>
         {services.map((service, num) => (
@@ -22,7 +38,7 @@ const Home: React.FC = () => {
           </li>
         ))}
       </ul>
-    </div>
+    </main>
   );
 };
 

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -11,24 +11,9 @@ const Home: React.FC = () => {
     { id: "3", name: "service3" },
     { id: "4", name: "service4" },
     { id: "5", name: "service5" },
-    { id: "6", name: "service6" },
-    { id: "7", name: "service7" },
-    { id: "8", name: "service8" },
-    { id: "9", name: "service9" },
-    { id: "10", name: "service10" },
-    { id: "11", name: "service11" },
-    { id: "12", name: "service12" },
-    { id: "13", name: "service13" },
-    { id: "14", name: "service14" },
-    { id: "15", name: "service15" },
-    { id: "16", name: "service16" },
-    { id: "17", name: "service17" },
-    { id: "18", name: "service18" },
-    { id: "19", name: "service19" },
-    { id: "20", name: "service20" },
   ];
   return (
-    <main>
+    <div className={styles.pageHeader}>
       <Header mode={HeaderMode.SERVICES} />
 
       <ul className={styles.serviceList}>
@@ -38,7 +23,7 @@ const Home: React.FC = () => {
           </li>
         ))}
       </ul>
-    </main>
+    </div>
   );
 };
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -18,6 +18,7 @@ const Header = ({ mode }: { mode: HeaderMode }) => {
         alignItems: "flex-end",
         boxShadow: "none",
         backgroundColor: "#85D5F3",
+        borderRadius: "0 0 20px 20px",
       }}
     >
       <Box sx={{ textAlign: "left", padding: "1rem" }}>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,8 +4,9 @@ import AppBar from "@mui/material/AppBar";
 import Typography from "@mui/material/Typography";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
+import { HeaderMode } from "@/types/HeaderMode";
 
-const Header = () => {
+const Header = ({ mode }: { mode: HeaderMode }) => {
   return (
     <AppBar
       sx={{
@@ -16,6 +17,7 @@ const Header = () => {
         alignContent: "flex-end",
         alignItems: "flex-end",
         boxShadow: "none",
+        backgroundColor: "#85D5F3",
       }}
     >
       <Box sx={{ textAlign: "left", padding: "1rem" }}>
@@ -63,14 +65,22 @@ const Header = () => {
       >
         <Button
           sx={{
-            backgroundColor: "white",
+            backgroundColor:
+              mode === HeaderMode.SERVICES ? "#FAFBFB" : "#00AEEF",
             padding: "1rem 2rem 0.8rem 2rem",
             borderRadius: "1rem 1rem 0 0",
             height: "100%",
+            transition: "padding-bottom 0.2s",
+            "&:hover": {
+              paddingBottom: "1.6rem",
+              backgroundColor:
+                mode === HeaderMode.SERVICES ? "#FAFBFB" : "#00AEEF",
+            },
           }}
         >
           <Typography
             sx={{
+              color: mode === HeaderMode.SERVICES ? "#4D4D4D" : "white",
               fontFamily: "HannariMincho",
             }}
           >
@@ -79,14 +89,21 @@ const Header = () => {
         </Button>
         <Button
           sx={{
-            backgroundColor: "white",
+            backgroundColor: mode === HeaderMode.EVENTS ? "#FAFBFB" : "#00AEEF",
             padding: "1rem 2rem 0.8rem 2rem",
             borderRadius: "1rem 1rem 0 0",
             height: "100%",
+            transition: "padding-bottom 0.2s",
+            "&:hover": {
+              paddingBottom: "1.6rem",
+              backgroundColor:
+                mode === HeaderMode.EVENTS ? "#FAFBFB" : "#00AEEF",
+            },
           }}
         >
           <Typography
             sx={{
+              color: mode === HeaderMode.EVENTS ? "#4D4D4D" : "white",
               fontFamily: "HannariMincho",
             }}
           >
@@ -95,20 +112,30 @@ const Header = () => {
         </Button>
         <Button
           sx={{
-            padding: "0.8rem 2rem",
-            borderRadius: "1rem 1rem 0 0",
+            padding: "0.4rem 1rem",
           }}
         >
-          <Typography
+          <Box
             sx={{
-              fontFamily: "HannariMincho",
-              lineHeight: "1.25",
+              padding: "0.4rem 1rem",
+              borderRadius: "1rem",
+              "&:hover": {
+                background: "#00AEEF33",
+              },
             }}
           >
-            管理者
-            <br />
-            ページ
-          </Typography>
+            <Typography
+              sx={{
+                fontFamily: "HannariMincho",
+                lineHeight: "1.25",
+                color: "white",
+              }}
+            >
+              管理者
+              <br />
+              ページ
+            </Typography>
+          </Box>
         </Button>
       </Box>
     </AppBar>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -70,9 +70,11 @@ const Header = ({ mode }: { mode: HeaderMode }) => {
             sx={{
               backgroundColor:
                 mode === HeaderMode.SERVICES ? "#FAFBFB" : "#00AEEF",
-              padding: "1rem 2rem 0.8rem 2rem",
+              padding: "1rem",
+              paddingBottom: "0.8rem",
               borderRadius: "1rem 1rem 0 0",
               height: "100%",
+              width: "10rem",
               transition: "padding-bottom 0.2s",
               "&:hover": {
                 paddingBottom: "1.6rem",
@@ -97,10 +99,12 @@ const Header = ({ mode }: { mode: HeaderMode }) => {
             sx={{
               backgroundColor:
                 mode === HeaderMode.EVENTS ? "#FAFBFB" : "#00AEEF",
-              padding: "1rem 2rem 0.8rem 2rem",
+              padding: "1rem",
+              paddingBottom: "0.8rem",
               borderRadius: "1rem 1rem 0 0",
               height: "100%",
               transition: "padding-bottom 0.2s",
+              width: "10rem",
               "&:hover": {
                 paddingBottom: "1.6rem",
                 backgroundColor:

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,10 +1,11 @@
+"use client";
 import React from "react";
 import Image from "next/image";
 import AppBar from "@mui/material/AppBar";
 import Typography from "@mui/material/Typography";
 import Box from "@mui/material/Box";
-import Button from "@mui/material/Button";
 import { HeaderMode } from "@/types/HeaderMode";
+import Link from "next/link";
 
 const Header = ({ mode }: { mode: HeaderMode }) => {
   return (
@@ -64,80 +65,89 @@ const Header = ({ mode }: { mode: HeaderMode }) => {
           height: "100%",
         }}
       >
-        <Button
-          sx={{
-            backgroundColor:
-              mode === HeaderMode.SERVICES ? "#FAFBFB" : "#00AEEF",
-            padding: "1rem 2rem 0.8rem 2rem",
-            borderRadius: "1rem 1rem 0 0",
-            height: "100%",
-            transition: "padding-bottom 0.2s",
-            "&:hover": {
-              paddingBottom: "1.6rem",
-              backgroundColor:
-                mode === HeaderMode.SERVICES ? "#FAFBFB" : "#00AEEF",
-            },
-          }}
-        >
-          <Typography
-            sx={{
-              color: mode === HeaderMode.SERVICES ? "#4D4D4D" : "white",
-              fontFamily: "HannariMincho",
-            }}
-          >
-            サービス一覧
-          </Typography>
-        </Button>
-        <Button
-          sx={{
-            backgroundColor: mode === HeaderMode.EVENTS ? "#FAFBFB" : "#00AEEF",
-            padding: "1rem 2rem 0.8rem 2rem",
-            borderRadius: "1rem 1rem 0 0",
-            height: "100%",
-            transition: "padding-bottom 0.2s",
-            "&:hover": {
-              paddingBottom: "1.6rem",
-              backgroundColor:
-                mode === HeaderMode.EVENTS ? "#FAFBFB" : "#00AEEF",
-            },
-          }}
-        >
-          <Typography
-            sx={{
-              color: mode === HeaderMode.EVENTS ? "#4D4D4D" : "white",
-              fontFamily: "HannariMincho",
-            }}
-          >
-            イベント一覧
-          </Typography>
-        </Button>
-        <Button
-          sx={{
-            padding: "0.4rem 1rem",
-          }}
-        >
+        <Link href={"/services"}>
           <Box
             sx={{
-              padding: "0.4rem 1rem",
-              borderRadius: "1rem",
+              backgroundColor:
+                mode === HeaderMode.SERVICES ? "#FAFBFB" : "#00AEEF",
+              padding: "1rem 2rem 0.8rem 2rem",
+              borderRadius: "1rem 1rem 0 0",
+              height: "100%",
+              transition: "padding-bottom 0.2s",
               "&:hover": {
-                background: "#00AEEF33",
+                paddingBottom: "1.6rem",
+                backgroundColor:
+                  mode === HeaderMode.SERVICES ? "#FAFBFB" : "#00AEEF",
               },
             }}
           >
             <Typography
               sx={{
+                color: mode === HeaderMode.SERVICES ? "#4D4D4D" : "white",
                 fontFamily: "HannariMincho",
-                lineHeight: "1.25",
-                color: "white",
               }}
             >
-              管理者
-              <br />
-              ページ
+              サービス一覧
             </Typography>
           </Box>
-        </Button>
+        </Link>
+
+        <Link href={"/events"}>
+          <Box
+            sx={{
+              backgroundColor:
+                mode === HeaderMode.EVENTS ? "#FAFBFB" : "#00AEEF",
+              padding: "1rem 2rem 0.8rem 2rem",
+              borderRadius: "1rem 1rem 0 0",
+              height: "100%",
+              transition: "padding-bottom 0.2s",
+              "&:hover": {
+                paddingBottom: "1.6rem",
+                backgroundColor:
+                  mode === HeaderMode.EVENTS ? "#FAFBFB" : "#00AEEF",
+              },
+            }}
+          >
+            <Typography
+              sx={{
+                color: mode === HeaderMode.EVENTS ? "#4D4D4D" : "white",
+                fontFamily: "HannariMincho",
+              }}
+            >
+              イベント一覧
+            </Typography>
+          </Box>
+        </Link>
+
+        <Link href={"/admin"}>
+          <Box
+            sx={{
+              padding: "0.4rem 1rem",
+            }}
+          >
+            <Box
+              sx={{
+                padding: "0.4rem 1rem",
+                borderRadius: "1rem",
+                "&:hover": {
+                  background: "#00AEEF33",
+                },
+              }}
+            >
+              <Typography
+                sx={{
+                  fontFamily: "HannariMincho",
+                  lineHeight: "1.25",
+                  color: "white",
+                }}
+              >
+                管理者
+                <br />
+                ページ
+              </Typography>
+            </Box>
+          </Box>
+        </Link>
       </Box>
     </AppBar>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,14 +1,71 @@
 import React from "react";
+import Image from "next/image";
 import AppBar from "@mui/material/AppBar";
+import Typography from "@mui/material/Typography";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
 
 const Header = () => {
   return (
-    <AppBar>
-      <p>watnowプロダクト一覧サイト</p>
-      <h1>watbox</h1>
-      <p>サービス一覧</p>
-      <p>イベント一覧</p>
-      <p>管理者ページ</p>
+    <AppBar
+      sx={{
+        display: "flex",
+        flexDirection: "row",
+        justifyContent: "space-between",
+        padding: "1rem",
+      }}
+    >
+      <Box sx={{ textAlign: "left" }}>
+        <Typography
+          variant="h6"
+          component="div"
+          sx={{
+            fontSize: "1.25rem",
+            fontFamily: "HannariMincho",
+            lineHeight: "0.85",
+            fontWeight: "regular",
+            color: "#3F4154",
+          }}
+        >
+          watnowプロダクト一覧サイト
+        </Typography>
+        <Box sx={{ display: "flex" }}>
+          <Typography
+            variant="h6"
+            component="div"
+            sx={{
+              fontSize: "4rem",
+              fontFamily: "HannariMincho",
+              lineHeight: "0.85",
+              fontWeight: "regular",
+            }}
+          >
+            watbox
+          </Typography>
+          <Image
+            src={"/paper_airplane.svg"}
+            alt={"紙飛行機のアイコン"}
+            height={56}
+            width={56}
+          />
+        </Box>
+      </Box>
+
+      <Box>
+        <Button>
+          <Typography>サービス一覧</Typography>
+        </Button>
+        <Button>
+          <Typography>イベント一覧</Typography>
+        </Button>
+        <Button>
+          <Typography>
+            管理者
+            <br />
+            ページ
+          </Typography>
+        </Button>
+      </Box>
     </AppBar>
   );
 };

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,18 +1,16 @@
 import React from "react";
-import styles from "./Header.module.css";
+import AppBar from "@mui/material/AppBar";
 
-
-const Header = () =>{
+const Header = () => {
   return (
-    <header className={styles.header}>
-        <p>watnowプロダクト一覧サイト</p>
-        <h1>watbox</h1>
-        <p>サービス一覧</p>
-        <p>イベント一覧</p>
-        <p>管理者ページ</p>
-    </header>
+    <AppBar>
+      <p>watnowプロダクト一覧サイト</p>
+      <h1>watbox</h1>
+      <p>サービス一覧</p>
+      <p>イベント一覧</p>
+      <p>管理者ページ</p>
+    </AppBar>
   );
 };
 
 export default Header;
-

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -12,10 +12,13 @@ const Header = () => {
         display: "flex",
         flexDirection: "row",
         justifyContent: "space-between",
-        padding: "1rem",
+        padding: "0 2rem",
+        alignContent: "flex-end",
+        alignItems: "flex-end",
+        boxShadow: "none",
       }}
     >
-      <Box sx={{ textAlign: "left" }}>
+      <Box sx={{ textAlign: "left", padding: "1rem" }}>
         <Typography
           variant="h6"
           component="div"
@@ -51,15 +54,57 @@ const Header = () => {
         </Box>
       </Box>
 
-      <Box>
-        <Button>
-          <Typography>サービス一覧</Typography>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "flex-end",
+          height: "100%",
+        }}
+      >
+        <Button
+          sx={{
+            backgroundColor: "white",
+            padding: "1rem 2rem 0.8rem 2rem",
+            borderRadius: "1rem 1rem 0 0",
+            height: "100%",
+          }}
+        >
+          <Typography
+            sx={{
+              fontFamily: "HannariMincho",
+            }}
+          >
+            サービス一覧
+          </Typography>
         </Button>
-        <Button>
-          <Typography>イベント一覧</Typography>
+        <Button
+          sx={{
+            backgroundColor: "white",
+            padding: "1rem 2rem 0.8rem 2rem",
+            borderRadius: "1rem 1rem 0 0",
+            height: "100%",
+          }}
+        >
+          <Typography
+            sx={{
+              fontFamily: "HannariMincho",
+            }}
+          >
+            イベント一覧
+          </Typography>
         </Button>
-        <Button>
-          <Typography>
+        <Button
+          sx={{
+            padding: "0.8rem 2rem",
+            borderRadius: "1rem 1rem 0 0",
+          }}
+        >
+          <Typography
+            sx={{
+              fontFamily: "HannariMincho",
+              lineHeight: "1.25",
+            }}
+          >
             管理者
             <br />
             ページ

--- a/src/types/HeaderMode.ts
+++ b/src/types/HeaderMode.ts
@@ -1,0 +1,5 @@
+export enum HeaderMode {
+  NONE = "none",
+  SERVICES = "services",
+  EVENTS = "events",
+}


### PR DESCRIPTION
## 実装内容
   - HeaderにFigmaのデザインを当てた
   - 画面遷移の処理を追加した
## 関連issue
   - #50 
## 結果画像

https://github.com/user-attachments/assets/15d65c04-d955-4c64-a613-66e9a2810080


## 特にみて欲しい部分
   - 
## 今回作れなかった部分
   - Headerとコンテンツの境目の細かいライン
   - 背景の透明度の調整(ちさと相談中)
   - 上部の固定(ちさと相談中)
## 補足
   - 使い方
   - `<Header mode={***} />`
   - ***には、サービス一覧画面なら `mode={HeaderMode.SERVICES}` を、イベント一覧画面なら `mode={HeaderMode.EVENTS}` を、それ以外は `mode={HeaderMode.NONE}` を指定