### PR TITLE
mainタグにあてていたスタイル修正

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -23,7 +23,7 @@ body {
 }
 
 main {
-  padding-top: 160px;
+  padding-top: calc(32px + 5rem);
   min-height: 100vh;
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -23,7 +23,8 @@ body {
 }
 
 main {
-  margin-top: 160px;
+  padding-top: 160px;
+  min-height: 100vh;
 }
 
 a {


### PR DESCRIPTION
## 実装内容
   - Header作成時にglobals.cssでmainタグにmarginを当てたが、paddingの方が良かったため修正した
## 関連issue
   - 
## 結果画像
   - 
## 特にみて欲しい部分
   - 
## 今回作れなかった部分
   - 
## 補足
   - Headerを反映させた人は早めにこれも反映した方が良さそう。申し訳