### PR TITLE
Headerのスタイル修正・リファクタリング

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -76,6 +76,7 @@ const Header = ({ mode }: { mode: HeaderMode }) => {
               height: "100%",
               width: "10rem",
               transition: "padding-bottom 0.2s",
+              textAlign: "center",
               "&:hover": {
                 paddingBottom: "1.6rem",
                 backgroundColor:
@@ -104,6 +105,7 @@ const Header = ({ mode }: { mode: HeaderMode }) => {
               borderRadius: "1rem 1rem 0 0",
               height: "100%",
               transition: "padding-bottom 0.2s",
+              textAlign: "center",
               width: "10rem",
               "&:hover": {
                 paddingBottom: "1.6rem",

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,7 +8,15 @@ import { HeaderMode } from "@/types/HeaderMode";
 import Link from "next/link";
 
 const Header = ({ mode }: { mode: HeaderMode }) => {
-  const TabLink = (linkMode: HeaderMode, href: string, text: string) => (
+  const TabLink = ({
+    linkMode,
+    href,
+    text,
+  }: {
+    linkMode: HeaderMode;
+    href: string;
+    text: string;
+  }) => (
     <Link href={href}>
       <Box
         sx={{
@@ -94,8 +102,16 @@ const Header = ({ mode }: { mode: HeaderMode }) => {
           height: "100%",
         }}
       >
-        {TabLink(HeaderMode.SERVICES, "/services", "サービス一覧")}
-        {TabLink(HeaderMode.EVENTS, "/events", "イベント一覧")}
+        <TabLink
+          linkMode={HeaderMode.SERVICES}
+          href={"/services"}
+          text={"サービス一覧"}
+        />
+        <TabLink
+          linkMode={HeaderMode.EVENTS}
+          href={"/events"}
+          text={"イベント一覧"}
+        />
 
         <Link href={"/admin"}>
           <Box

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -79,8 +79,6 @@ const Header = ({ mode }: { mode: HeaderMode }) => {
               textAlign: "center",
               "&:hover": {
                 paddingBottom: "1.6rem",
-                backgroundColor:
-                  mode === HeaderMode.SERVICES ? "#FAFBFB" : "#00AEEF",
               },
             }}
           >
@@ -109,8 +107,6 @@ const Header = ({ mode }: { mode: HeaderMode }) => {
               width: "10rem",
               "&:hover": {
                 paddingBottom: "1.6rem",
-                backgroundColor:
-                  mode === HeaderMode.EVENTS ? "#FAFBFB" : "#00AEEF",
               },
             }}
           >

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,6 +8,35 @@ import { HeaderMode } from "@/types/HeaderMode";
 import Link from "next/link";
 
 const Header = ({ mode }: { mode: HeaderMode }) => {
+  const TabLink = (linkMode: HeaderMode, href: string, text: string) => (
+    <Link href={href}>
+      <Box
+        sx={{
+          backgroundColor: mode === linkMode ? "#FAFBFB" : "#00AEEF",
+          padding: "1rem",
+          paddingBottom: "0.8rem",
+          borderRadius: "1rem 1rem 0 0",
+          height: "100%",
+          width: "10rem",
+          transition: "padding-bottom 0.2s",
+          textAlign: "center",
+          "&:hover": {
+            paddingBottom: "1.6rem",
+          },
+        }}
+      >
+        <Typography
+          sx={{
+            color: mode === linkMode ? "#4D4D4D" : "white",
+            fontFamily: "HannariMincho",
+          }}
+        >
+          {text}
+        </Typography>
+      </Box>
+    </Link>
+  );
+
   return (
     <AppBar
       sx={{
@@ -65,61 +94,8 @@ const Header = ({ mode }: { mode: HeaderMode }) => {
           height: "100%",
         }}
       >
-        <Link href={"/services"}>
-          <Box
-            sx={{
-              backgroundColor:
-                mode === HeaderMode.SERVICES ? "#FAFBFB" : "#00AEEF",
-              padding: "1rem",
-              paddingBottom: "0.8rem",
-              borderRadius: "1rem 1rem 0 0",
-              height: "100%",
-              width: "10rem",
-              transition: "padding-bottom 0.2s",
-              textAlign: "center",
-              "&:hover": {
-                paddingBottom: "1.6rem",
-              },
-            }}
-          >
-            <Typography
-              sx={{
-                color: mode === HeaderMode.SERVICES ? "#4D4D4D" : "white",
-                fontFamily: "HannariMincho",
-              }}
-            >
-              サービス一覧
-            </Typography>
-          </Box>
-        </Link>
-
-        <Link href={"/events"}>
-          <Box
-            sx={{
-              backgroundColor:
-                mode === HeaderMode.EVENTS ? "#FAFBFB" : "#00AEEF",
-              padding: "1rem",
-              paddingBottom: "0.8rem",
-              borderRadius: "1rem 1rem 0 0",
-              height: "100%",
-              transition: "padding-bottom 0.2s",
-              textAlign: "center",
-              width: "10rem",
-              "&:hover": {
-                paddingBottom: "1.6rem",
-              },
-            }}
-          >
-            <Typography
-              sx={{
-                color: mode === HeaderMode.EVENTS ? "#4D4D4D" : "white",
-                fontFamily: "HannariMincho",
-              }}
-            >
-              イベント一覧
-            </Typography>
-          </Box>
-        </Link>
+        {TabLink(HeaderMode.SERVICES, "/services", "サービス一覧")}
+        {TabLink(HeaderMode.EVENTS, "/events", "イベント一覧")}
 
         <Link href={"/admin"}>
           <Box


### PR DESCRIPTION
## 実装内容
   - 文字が中央寄せできていない画面があったので `text-align: center` で統一
   - `TabLink` というコンポーネントに共通化
## 関連issue
   -
## 結果画像
   - #54 と同じ
## 特にみて欲しい部分
   - 
## 今回作れなかった部分
   - 
## 補足
   - 