### PR TITLE
非公開ユーザは鍵マークが出るようにした

### DIFF
--- a/public/lock.svg
+++ b/public/lock.svg
@@ -1,0 +1,11 @@
+<svg width="120" height="114" viewBox="0 0 120 114" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M82 45C82 62.6654 70.6644 74 60 74C49.3356 74 38 62.6654 38 45C38 27.3346 49.3356 16 60 16C70.6644 16 82 27.3346 82 45Z" stroke="black" stroke-width="16"/>
+<path d="M60 86C79.5206 86 94 66.8191 94 45C94 23.1809 79.5206 4 60 4C40.4794 4 26 23.1809 26 45C26 66.8191 40.4794 86 60 86Z" stroke="black" stroke-width="8"/>
+<path d="M86 45C86 64.05 73.6165 78 60 78C46.3835 78 34 64.05 34 45C34 25.95 46.3835 12 60 12C73.6165 12 86 25.95 86 45Z" stroke="#9CABC7" stroke-width="8"/>
+<rect x="4" y="38" width="112" height="72" rx="12" fill="#F3DF85" stroke="black" stroke-width="8"/>
+<circle cx="60" cy="82" r="12" fill="black"/>
+<circle cx="43" cy="72" r="5" fill="black"/>
+<circle cx="77" cy="72" r="5" fill="black"/>
+<circle cx="54" cy="64" r="5" fill="black"/>
+<circle cx="66" cy="64" r="5" fill="black"/>
+</svg>

--- a/src/app/users/[account_id]/page.tsx
+++ b/src/app/users/[account_id]/page.tsx
@@ -15,6 +15,7 @@ import DetailContainer from "@/components/DetailContainer";
 import DetailHeader from "@/components/DetailHeader";
 import DisplaySNS from "@/components/userDetails/DisplaySNS";
 import ServiceCard from "@/components/ServiceCard";
+import ServicesContainer from "@/components/ServicesContainer";
 
 const UserPage = ({ params }: { params: { account_id: string } }) => {
   const accountID = params.account_id;
@@ -68,11 +69,11 @@ const UserPage = ({ params }: { params: { account_id: string } }) => {
 
             <DetailContainer>
               <DetailHeader title={"作成したサービス"} />
-              <ItemList>
+              <ServicesContainer>
                 {userData.services.map((service, index) => (
                   <ServiceCard key={index} service={service} />
                 ))}
-              </ItemList>
+              </ServicesContainer>
             </DetailContainer>
           </>
         )}

--- a/src/app/users/[account_id]/page.tsx
+++ b/src/app/users/[account_id]/page.tsx
@@ -37,7 +37,6 @@ const UserPage = ({ params }: { params: { account_id: string } }) => {
     <main className={styles.main}>
       <Header mode={HeaderMode.NONE} />
 
-      {/* TODO: 森岡のHeader当てる */}
       <Box
         sx={{
           width: "100%",
@@ -51,28 +50,32 @@ const UserPage = ({ params }: { params: { account_id: string } }) => {
 
         <DisplayIconAndName user={userData} />
 
-        <DetailContainer>
-          <DetailHeader title="技術スタック" />
-          <ItemList>
-            {userData.technologies.map((tech) => (
-              <TechItem key={tech.id} technology={tech} />
-            ))}
-          </ItemList>
-        </DetailContainer>
+        {userData.isVisible && (
+          <>
+            <DetailContainer>
+              <DetailHeader title="技術スタック" />
+              <ItemList>
+                {userData.technologies.map((tech) => (
+                  <TechItem key={tech.id} technology={tech} />
+                ))}
+              </ItemList>
+            </DetailContainer>
 
-        <DetailContainer>
-          <DetailHeader title="各種SNSアカウント" />
-          <DisplaySNS user={userData} />
-        </DetailContainer>
+            <DetailContainer>
+              <DetailHeader title="各種SNSアカウント" />
+              <DisplaySNS user={userData} />
+            </DetailContainer>
 
-        <DetailContainer>
-          <DetailHeader title={"作成したサービス"} />
-          <ItemList>
-            {userData.services.map((service, index) => (
-              <ServiceCard key={index} service={service} />
-            ))}
-          </ItemList>
-        </DetailContainer>
+            <DetailContainer>
+              <DetailHeader title={"作成したサービス"} />
+              <ItemList>
+                {userData.services.map((service, index) => (
+                  <ServiceCard key={index} service={service} />
+                ))}
+              </ItemList>
+            </DetailContainer>
+          </>
+        )}
       </Box>
     </main>
   );

--- a/src/components/ServicesContainer.tsx
+++ b/src/components/ServicesContainer.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { Box } from "@mui/material";
+
+const ServicesContainer = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <Box
+      sx={{
+        width: "100%",
+        margin: "33px 0 0 0",
+        display: "grid",
+        gridTemplateColumns: "repeat(1, minmax(0, 368px))",
+        gridTemplateRows: "repeat(auto-fit, minmax(0, 306px))",
+        justifyContent: "center",
+        columnGap: "60px",
+        rowGap: "56px",
+        "@media screen and (min-width: 840px)": {
+          gridTemplateColumns: "repeat(2, minmax(0, 368px))",
+          gridTemplateRows: "repeat(auto-fit, minmax(0, 306px))",
+          justifyContent: "center",
+          columnGap: "60px",
+          rowGap: "40px",
+        },
+        "@media screen and (min-width: 1200px)": {
+          gridTemplateColumns: "repeat(3, minmax(0, 368px))",
+        },
+      }}
+    >
+      {children}
+    </Box>
+  );
+};
+
+export default ServicesContainer;

--- a/src/components/userDetails/DisplayIconAndName.tsx
+++ b/src/components/userDetails/DisplayIconAndName.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import { Box, Typography, Avatar } from "@mui/material";
 import type { UserDetail } from "@/types/User";
 import DottedDivider from "@/components/DottedDivider";
@@ -5,7 +6,7 @@ import DottedDivider from "@/components/DottedDivider";
 interface DisplayIconAndNameProps
   extends Pick<
     UserDetail,
-    "nickname" | "accountID" | "introduction" | "image"
+    "nickname" | "accountID" | "introduction" | "image" | "isVisible"
   > {}
 
 const DisplayIconAndName = ({ user }: { user: DisplayIconAndNameProps }) => {
@@ -123,24 +124,67 @@ const DisplayIconAndName = ({ user }: { user: DisplayIconAndNameProps }) => {
             </Typography>
           </Box>
           <DottedDivider color="#878686" />
-          <Typography
-            variant="body1"
-            sx={{
-              fontSize: "1.4rem",
-              fontFamily: "HannariMincho",
-              padding: "8px",
-              //   はみ出たら折り返す
-              overflowWrap: "break-word",
-              "@media screen and (max-width: 900px)": {
-                fontSize: "1.25rem",
-              },
-              "@media screen and (max-width: 500px)": {
-                fontSize: "0.75rem",
-              },
-            }}
-          >
-            {user.introduction}
-          </Typography>
+          {user.isVisible ? (
+            <Typography
+              variant="body1"
+              sx={{
+                fontSize: "1.4rem",
+                fontFamily: "HannariMincho",
+                padding: "8px",
+                //   はみ出たら折り返す
+                overflowWrap: "break-word",
+                "@media screen and (max-width: 900px)": {
+                  fontSize: "1.25rem",
+                },
+                "@media screen and (max-width: 500px)": {
+                  fontSize: "0.75rem",
+                },
+              }}
+            >
+              {user.introduction}
+            </Typography>
+          ) : (
+            <Box
+              sx={{
+                paddingTop: "80px",
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                justifyContent: "center",
+                "@media screen and (max-width: 750px)": {
+                  paddingTop: "30px",
+                },
+                "@media screen and (max-width: 500px)": {
+                  paddingTop: "20px",
+                },
+              }}
+            >
+              <Image
+                src="/lock.svg"
+                alt={"南京錠の画像"}
+                width={40}
+                height={40}
+              />
+              <Typography
+                variant="body1"
+                sx={{
+                  fontSize: "1.4rem",
+                  fontFamily: "HannariMincho",
+                  textAlign: "center",
+                  //   はみ出たら折り返す
+                  overflowWrap: "break-word",
+                  "@media screen and (max-width: 900px)": {
+                    fontSize: "1.25rem",
+                  },
+                  "@media screen and (max-width: 500px)": {
+                    fontSize: "0.75rem",
+                  },
+                }}
+              >
+                非公開ユーザです
+              </Typography>
+            </Box>
+          )}
         </Box>
       </Box>
     </Box>


### PR DESCRIPTION
## 実装内容
   - 非公開ユーザは鍵マークが出るようにした
     - 非公開ユーザの自己紹介、技術スタック、SNSアカウント、作ったサービス一覧を非表示
     - 代わりに南京錠のイラストを表示
## 関連issue
   - 
## 結果画像
| 公開 | | | |
|--------|--------|--------|--------|
| 公開 | <img width="321" alt="スクリーンショット 2024-12-03 15 09 49" src="https://github.com/user-attachments/assets/56648596-46b9-4c1c-b6d1-429e167323ee"> | <img width="1470" alt="スクリーンショット 2024-12-03 15 10 24" src="https://github.com/user-attachments/assets/8ac6c4b2-9816-4e16-a749-4569c35cb72b"> | <img width="1470" alt="スクリーンショット 2024-12-03 15 10 28" src="https://github.com/user-attachments/assets/ff8160d9-8da5-4e7e-9fb0-40606a219132"> |
| 非公開 |  <img width="317" alt="スクリーンショット 2024-12-03 15 10 09" src="https://github.com/user-attachments/assets/ca5eeb03-b4e1-4349-8e8d-673066ea6618"> | <img width="1470" alt="スクリーンショット 2024-12-03 15 10 14" src="https://github.com/user-attachments/assets/e0e27667-6685-478f-981d-a5b2862b1f23"> | |

## 特にみて欲しい部分
   - 
## 今回作れなかった部分
   - 
## 補足
   - 