### PR TITLE
はんなり明朝を theme.ts で指定して各 Typography で自動的にフォントが当たるようにする

### DIFF
--- a/src/components/DetailHeader.tsx
+++ b/src/components/DetailHeader.tsx
@@ -9,7 +9,6 @@ const DetailHeader = ({ title }: { title: string }) => {
         sx={{
           paddingLeft: "8px",
           fontSize: "1.5rem",
-          fontFamily: "HannariMincho",
           color: "#00AEEF",
         }}
       >

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -48,7 +48,6 @@ export const EventCard: React.FC<EventCardProp> = ({ event }) => {
         border: "1px solid",
         borderColor: "#fff",
         boxShadow: "none",
-        fontFamily: "HannariMincho", // カスタムフォントを指定
       }}
     >
       <Box
@@ -61,7 +60,6 @@ export const EventCard: React.FC<EventCardProp> = ({ event }) => {
           paddingLeft: "1rem",
           paddingRight: "1rem",
           position: "relative",
-          fontFamily: "HannariMincho",
         }}
       >
         {/* 日付を表示 */}
@@ -72,7 +70,6 @@ export const EventCard: React.FC<EventCardProp> = ({ event }) => {
             fontSize: "1.4rem", // カスタムフォントサイズを指定
             backgroundColor: "#fff",
             padding: "0.5rem 1rem", // 上下左右の余白
-            fontFamily: "HannariMincho",
           }}
         >
           {event.date}
@@ -89,7 +86,6 @@ export const EventCard: React.FC<EventCardProp> = ({ event }) => {
                 "&:hover": {
                   backgroundColor: "#D9D9D9", // ホバー時の背景色を濃くする
                 },
-                fontFamily: "HannariMincho",
               }}
             >
               詳細をみる
@@ -163,7 +159,6 @@ export const EventCard: React.FC<EventCardProp> = ({ event }) => {
             alignItems: "flex-start",
             height: "100%",
             width: "60%", // 幅を相対的に設定
-            fontFamily: "HannariMincho",
           }}
         >
           <CardContent
@@ -186,7 +181,6 @@ export const EventCard: React.FC<EventCardProp> = ({ event }) => {
                   whiteSpace: "nowrap", // テキストを1行に制限
                   overflow: "hidden", // あふれた部分を非表示に
                   textOverflow: "ellipsis", // あふれた部分を "..." に
-                  fontFamily: "HannariMincho",
                 }}
               >
                 {event.name}
@@ -206,7 +200,6 @@ export const EventCard: React.FC<EventCardProp> = ({ event }) => {
                   WebkitBoxOrient: "vertical",
                   overflow: "hidden",
                   textOverflow: "ellipsis", // あふれた部分を "..." で表示
-                  fontFamily: "HannariMincho",
                 }}
               >
                 {event.comment}

--- a/src/components/EventYearList.tsx
+++ b/src/components/EventYearList.tsx
@@ -95,7 +95,6 @@ export const EventYearList: React.FC<EventYearListProps> = ({
             alignItems: "center",
             padding: "10px 0",
             marginLeft: "20px",
-            fontFamily: "HannariMincho",
           }}
           disablePadding
         >
@@ -134,7 +133,6 @@ export const EventYearList: React.FC<EventYearListProps> = ({
               sx={{
                 color: "gray",
                 fontSize: "18px",
-                fontFamily: "HannariMincho",
               }}
             >
               {event.count} event{event.count > 1 ? "s" : ""}
@@ -143,7 +141,6 @@ export const EventYearList: React.FC<EventYearListProps> = ({
             <Typography
               variant="h4"
               color="inherit"
-              sx={{ fontFamily: "HannariMincho" }}
             >
               {event.year}
             </Typography>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -31,7 +31,6 @@ const MobileHeader = () => {
     >
       <Typography
         sx={{
-          fontFamily: "HannariMincho",
           textAlign: "center",
         }}
       >
@@ -141,7 +140,6 @@ const DesktopHeader = ({ mode }: { mode: HeaderMode }) => {
         <Typography
           sx={{
             color: mode === linkMode ? "#4D4D4D" : "white",
-            fontFamily: "HannariMincho",
           }}
         >
           {text}
@@ -193,7 +191,6 @@ const DesktopHeader = ({ mode }: { mode: HeaderMode }) => {
             >
               <Typography
                 sx={{
-                  fontFamily: "HannariMincho",
                   lineHeight: "1.25",
                   color: "white",
                 }}
@@ -254,7 +251,6 @@ const CoreHeader = ({
             component="div"
             sx={{
               fontSize: "1.25rem",
-              fontFamily: "HannariMincho",
               lineHeight: "0.85",
               fontWeight: "regular",
               color: "#3F4154",
@@ -274,7 +270,6 @@ const CoreHeader = ({
               component="div"
               sx={{
                 fontSize: "4rem",
-                fontFamily: "HannariMincho",
                 lineHeight: "0.85",
                 fontWeight: "regular",
                 "@media screen and (max-width: 700px)": {

--- a/src/components/admin/AdminHeader.tsx
+++ b/src/components/admin/AdminHeader.tsx
@@ -26,7 +26,6 @@ const AdminHeader = ({ isEditing }: { isEditing?: boolean }) => {
         component="div"
         sx={{
           fontSize: "2.25rem",
-          fontFamily: "HannariMincho",
           lineHeight: "0.85",
           fontWeight: "regular",
           color: "white",
@@ -65,7 +64,6 @@ const AdminHeader = ({ isEditing }: { isEditing?: boolean }) => {
           <Typography
             sx={{
               fontSize: "1.5rem",
-              fontFamily: "HannariMincho",
               lineHeight: "0.85",
               fontWeight: "regular",
               color: "white",

--- a/src/components/admin/AdminTitle.tsx
+++ b/src/components/admin/AdminTitle.tsx
@@ -8,7 +8,6 @@ const AdminTitle = ({ children }: { children: React.ReactNode }) => {
       variant="h1"
       component="div"
       sx={{
-        fontFamily: "HannariMincho",
         fontSize: "4rem",
         padding: "1rem 0 28px 0",
         "@media screen and (max-width: 768px)": {

--- a/src/components/admin/PankuzuList.tsx
+++ b/src/components/admin/PankuzuList.tsx
@@ -18,7 +18,6 @@ const PankuzuList = ({ pankuzu }: { pankuzu: Pankuzu[] }) => {
             <Typography
               component="div"
               sx={{
-                fontFamily: "HannariMincho",
                 fontSize: "1.5rem",
                 color: "#0063BF",
                 borderBottom: "2px solid #0063BF",
@@ -34,7 +33,6 @@ const PankuzuList = ({ pankuzu }: { pankuzu: Pankuzu[] }) => {
             <Typography
               component="div"
               sx={{
-                fontFamily: "HannariMincho",
                 fontSize: "1.5rem",
                 color: "#0063BF",
               }}
@@ -44,42 +42,6 @@ const PankuzuList = ({ pankuzu }: { pankuzu: Pankuzu[] }) => {
           )}
         </React.Fragment>
       ))}
-      {/* <Link href={"/admin"}>
-        <Typography
-          component="div"
-          sx={{
-            fontFamily: "HannariMincho",
-            fontSize: "1.5rem",
-            color: "#0063BF",
-            borderBottom: "2px solid #0063BF",
-          }}
-        >
-          ジャンル選択
-        </Typography>
-      </Link>
-      <Typography
-        component="div"
-        sx={{
-          fontFamily: "HannariMincho",
-          fontSize: "1.5rem",
-          color: "#0063BF",
-        }}
-      >
-        ＞
-      </Typography>
-      <Link href={"/admin/users"}>
-        <Typography
-          component="div"
-          sx={{
-            fontFamily: "HannariMincho",
-            fontSize: "1.5rem",
-            color: "#0063BF",
-            borderBottom: "2px solid #0063BF",
-          }}
-        >
-          ユーザ
-        </Typography>
-      </Link> */}
     </Box>
   );
 };

--- a/src/components/admin/SelectYearOptions.tsx
+++ b/src/components/admin/SelectYearOptions.tsx
@@ -30,7 +30,6 @@ const SelectYearOptions = ({
     backgroundPosition: "left bottom",
     "& .MuiTypography-root": {
       flexGrow: 1,
-      fontFamily: "HannariMincho",
       fontSize: "1.5rem",
       color: "var(--text)",
     },

--- a/src/components/userDetails/DisplayIconAndName.tsx
+++ b/src/components/userDetails/DisplayIconAndName.tsx
@@ -94,7 +94,6 @@ const DisplayIconAndName = ({ user }: { user: DisplayIconAndNameProps }) => {
               sx={{
                 paddingLeft: "8px",
                 fontSize: "2rem",
-                fontFamily: "HannariMincho",
                 "@media screen and (max-width: 900px)": {
                   fontSize: "1.5rem",
                 },
@@ -110,7 +109,6 @@ const DisplayIconAndName = ({ user }: { user: DisplayIconAndNameProps }) => {
               sx={{
                 paddingLeft: "8px",
                 fontSize: "1.5rem",
-                fontFamily: "HannariMincho",
                 opacity: 0.8,
                 "@media screen and (max-width: 900px)": {
                   fontSize: "1.25rem",
@@ -129,7 +127,6 @@ const DisplayIconAndName = ({ user }: { user: DisplayIconAndNameProps }) => {
               variant="body1"
               sx={{
                 fontSize: "1.4rem",
-                fontFamily: "HannariMincho",
                 padding: "8px",
                 //   はみ出たら折り返す
                 overflowWrap: "break-word",
@@ -169,7 +166,6 @@ const DisplayIconAndName = ({ user }: { user: DisplayIconAndNameProps }) => {
                 variant="body1"
                 sx={{
                   fontSize: "1.4rem",
-                  fontFamily: "HannariMincho",
                   textAlign: "center",
                   //   はみ出たら折り返す
                   overflowWrap: "break-word",

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -11,6 +11,7 @@ const theme = createTheme({
     },
   },
   typography: {
+    fontFamily: "HannariMincho, sans-serif",
     allVariants: {
       color: "#4D4D4D",
     },


### PR DESCRIPTION
## 実装内容
   - MUI の `Typography` における `font-family: HannnariMincho` を `theme.ts` で指定した
   - 各 `Typography` から はんなり明朝 の指定コードを削除
## 関連issue
   -
## 結果画像
   - 
## 特にみて欲しい部分
   - 
## 今回作れなかった部分
   - 
## 補足
   - コンフリしたらごめんなさい