### PR TITLE
Headerのロゴの遷移先をサービス一覧からスプラッシュスクリーンに変更

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -234,7 +234,7 @@ const CoreHeader = ({
         },
       }}
     >
-      <Link href={"/services"}>
+      <Link href={"/"}>
         <Box
           sx={{
             minWidth: "18rem",


### PR DESCRIPTION
## 実装内容
   - Headerのロゴの遷移先をサービス一覧からスプラッシュスクリーンに変更した
## 関連issue
   - 
## 結果画像
   - 
## 特にみて欲しい部分
   - 
## 今回作れなかった部分
   - 
## 補足
   - 