### PR TITLE
エラー画面の作成

### DIFF
--- a/src/app/users/[account_id]/page.tsx
+++ b/src/app/users/[account_id]/page.tsx
@@ -16,6 +16,7 @@ import DetailHeader from "@/components/DetailHeader";
 import DisplaySNS from "@/components/userDetails/DisplaySNS";
 import ServiceCard from "@/components/ServiceCard";
 import ServicesContainer from "@/components/ServicesContainer";
+import ErrorPage from "@/components/error/ShowError";
 
 const UserPage = ({ params }: { params: { account_id: string } }) => {
   const accountID = params.account_id;
@@ -26,12 +27,7 @@ const UserPage = ({ params }: { params: { account_id: string } }) => {
   }
 
   if (!userData) {
-    return (
-      <main className={styles.main_center}>
-        <Header mode={HeaderMode.NONE} />
-        <h2>存在しないユーザです</h2>
-      </main>
-    );
+    return <ErrorPage errorMessage="存在しないユーザです" />;
   }
 
   return (

--- a/src/components/error/ShowError.tsx
+++ b/src/components/error/ShowError.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import Image from "next/image";
+import Box from "@mui/material/Box";
+import { Typography } from "@mui/material";
+import Header from "@/components/Header";
+import { HeaderMode } from "@/types/HeaderMode";
+
+const ShowError = ({ errorMessage }: { errorMessage: string }) => {
+  return (
+    <main>
+      <Header mode={HeaderMode.NONE} />
+      <Box
+        sx={{
+          backgroundColor: "#F8F8F8",
+          position: "fixed",
+          top: 0,
+          left: 0,
+          bottom: 0,
+          right: 0,
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          paddingTop: "48px",
+        }}
+      >
+        <Box
+          sx={{
+            position: "relative",
+            width: "100%",
+            height: "fit-content",
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+            marginTop: "4rem",
+          }}
+        >
+          {errorMessage && (
+            <Typography
+              variant="h1"
+              sx={{
+                width: "100%",
+                textAlign: "center",
+                fontSize: "2rem",
+                position: "absolute",
+                top: "20%",
+                left: "50%",
+                transform: "translate(-50%, -50%)",
+              }}
+            >
+              {errorMessage}
+            </Typography>
+          )}
+          <Image
+            src={"/cat.gif"}
+            alt={"猫ちゃんの画像"}
+            width={500}
+            height={500}
+            priority
+          />
+        </Box>
+      </Box>
+    </main>
+  );
+};
+
+export default ShowError;

--- a/src/components/error/ShowError.tsx
+++ b/src/components/error/ShowError.tsx
@@ -5,7 +5,13 @@ import { Typography } from "@mui/material";
 import Header from "@/components/Header";
 import { HeaderMode } from "@/types/HeaderMode";
 
-const ShowError = ({ errorMessage }: { errorMessage: string }) => {
+const ShowError = ({
+  errorMessage,
+  children,
+}: {
+  errorMessage?: string;
+  children?: React.ReactNode;
+}) => {
   return (
     <main>
       <Header mode={HeaderMode.NONE} />
@@ -30,6 +36,7 @@ const ShowError = ({ errorMessage }: { errorMessage: string }) => {
             width: "100%",
             height: "fit-content",
             display: "flex",
+            flexDirection: "column",
             justifyContent: "center",
             alignItems: "center",
             marginTop: "4rem",
@@ -39,24 +46,24 @@ const ShowError = ({ errorMessage }: { errorMessage: string }) => {
             <Typography
               variant="h1"
               sx={{
-                width: "100%",
-                textAlign: "center",
                 fontSize: "2rem",
-                position: "absolute",
-                top: "20%",
-                left: "50%",
-                transform: "translate(-50%, -50%)",
+                paddingBottom: "60px",
               }}
             >
               {errorMessage}
             </Typography>
           )}
+          {children}
           <Image
             src={"/cat.gif"}
             alt={"猫ちゃんの画像"}
             width={500}
             height={500}
             priority
+            style={{
+              margin: "-150px",
+              zIndex: -1,
+            }}
           />
         </Box>
       </Box>

--- a/src/components/error/ShowError.tsx
+++ b/src/components/error/ShowError.tsx
@@ -39,15 +39,24 @@ const ShowError = ({
             flexDirection: "column",
             justifyContent: "center",
             alignItems: "center",
-            marginTop: "4rem",
+            marginTop: "3rem",
           }}
         >
+          <Typography
+            variant="h1"
+            sx={{
+              fontSize: "2rem",
+              paddingBottom: "20px",
+            }}
+          >
+            Error
+          </Typography>
           {errorMessage && (
             <Typography
-              variant="h1"
+              variant="h2"
               sx={{
-                fontSize: "2rem",
-                paddingBottom: "60px",
+                fontSize: "1.5rem",
+                paddingBottom: "40px",
               }}
             >
               {errorMessage}


### PR DESCRIPTION
## 実装内容
   - エラー画面が人によってよって様々だったため、統一するためのコンポーネントを作成
## 関連issue
   - 
## 結果画像
| PC | モバイル端末 |
|--------|--------|
| <img width="364" alt="スクリーンショット 2025-02-05 19 02 47" src="https://github.com/user-attachments/assets/9e8d28dd-ccf6-4d7a-b695-eede89a6325c" /> | <img width="1470" alt="スクリーンショット 2025-02-05 19 02 55" src="https://github.com/user-attachments/assets/01e61c1b-9d47-45d3-bd45-25cc9e144c80" /> |





## 特にみて欲しい部分
   - 
## 今回作れなかった部分
   - 
## 補足
   - 